### PR TITLE
fix: Incorrect endpoint called from ProfileService

### DIFF
--- a/src/services/ProfileService.ts
+++ b/src/services/ProfileService.ts
@@ -12,6 +12,6 @@ export class ProfileService extends ApiService implements IProfileService {
   }
 
   async getPersonalDetails(): Promise<AxiosResponse<PersonalDetails>> {
-    return this.get<PersonalDetails>("/contactdetails");
+    return this.get<PersonalDetails>("/trainee-profile");
   }
 }


### PR DESCRIPTION
The endpoint used in ProfileService does not exist and should call
trainee-profile instead.

TISNEW-3946