### PR TITLE
feat: Added inline error messaging for text and select input components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11379,9 +11379,9 @@
       }
     },
     "nhsuk-react-components": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/nhsuk-react-components/-/nhsuk-react-components-1.0.1.tgz",
-      "integrity": "sha512-4AdHZ6I+yfP0anV+ObOK23lJJHFvfwHAFUgpoAg8CXol4OEYoD1JP6a/uK8BeevyBeXuXIbiWb+uO2WIUEYYpQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/nhsuk-react-components/-/nhsuk-react-components-1.1.3.tgz",
+      "integrity": "sha512-/1wV6Q2vkXrWW2w7e5VsCcGIiQ4DXcitXHUO6QIYsD4EV58n+Sg5+637sxlDBX1dhwzp38+OM3uaaN4L5PtLlg==",
       "requires": {
         "classnames": "^2.2.6"
       }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "formik": "^2.1.4",
     "moment": "^2.24.0",
     "nhsuk-frontend": "^3.0.2",
-    "nhsuk-react-components": "^1.0.0-rc.1",
+    "nhsuk-react-components": "^1.1.3",
     "node-sass": "^4.13.0",
     "react": "^16.12.0",
     "react-axe": "^3.3.0",

--- a/src/__snapshots__/App.snapshot.spec.tsx.snap
+++ b/src/__snapshots__/App.snapshot.spec.tsx.snap
@@ -20,7 +20,7 @@ Array [
             aria-labelledby="nhsuk-logo_title"
             className="nhsuk-logo"
             focusable="false"
-            role="presentation"
+            role="img"
             viewBox="0 0 40 16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -37,9 +37,9 @@ Array [
               className="nhsuk-logo__text"
               d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"
             />
-            <img
-              alt="NHS Logo"
+            <image
               src="https://assets.nhs.uk/images/nhs-logo.png"
+              xlinkHref=""
             />
           </svg>
         </a>

--- a/src/components/forms/InputFooterLabel.tsx
+++ b/src/components/forms/InputFooterLabel.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+interface InputFooterLabelProps {
+  label: string;
+}
+
+const InputFooterLabel: React.FC<InputFooterLabelProps> = ({ label }) => (
+  <>
+    {label ? (
+      <div style={{ color: "#900", fontSize: "9pt", paddingTop: "10px" }}>
+        {label}
+      </div>
+    ) : null}
+  </>
+);
+
+export default InputFooterLabel;

--- a/src/components/forms/SelectInputField.tsx
+++ b/src/components/forms/SelectInputField.tsx
@@ -13,9 +13,7 @@ interface Props {
 }
 
 const SelectInputField: React.FC<Props> = props => {
-  const [field, { error, touched }, helpers] = useField({
-    name: props.name
-  });
+  const [field, { error, touched }, helpers] = useField(props);
   return (
     <>
       <div
@@ -26,19 +24,22 @@ const SelectInputField: React.FC<Props> = props => {
         }
       >
         <Select
+          name={props.name}
           id={props.id || props.name}
           onBlur={() => {
             helpers.setTouched(true);
           }}
-          {...field}
-          {...props}
           error={error && touched ? error : ""}
           label={props.label}
+          onChange={field.onChange}
         >
           <Select.Option value="">-- Please select --</Select.Option>
           {props.options
             ? props.options.map((option: { value: string; label: string }) => (
-                <Select.Option key={option.label} value={option.value}>
+                <Select.Option
+                  selected={field.value === option.value ? true : false}
+                  value={option.value}
+                >
                   {option.label}
                 </Select.Option>
               ))

--- a/src/components/forms/SelectInputField.tsx
+++ b/src/components/forms/SelectInputField.tsx
@@ -1,28 +1,53 @@
-import { Field } from "formik";
 import React from "react";
-import { Label } from "nhsuk-react-components";
+import { connect, useField } from "formik";
+import { Select } from "nhsuk-react-components";
+import InputFooterLabel from "./InputFooterLabel";
 
-const SelectInputField: React.FC<any> = ({ label, options, ...field }) => {
+interface Props {
+  name: string;
+  label: string;
+  id?: string;
+  hint?: string;
+  options?: any[];
+  footer?: any;
+}
+
+const SelectInputField: React.FC<Props> = props => {
+  const [field, { error, touched }, helpers] = useField({
+    name: props.name
+  });
   return (
     <>
-      {label && label !== "" ? <Label>{label}</Label> : null}
-      <Field
-        className="nhsuk-select"
-        as="select"
-        {...field}
-        style={{ width: "100%", marginBottom: 10 }}
+      <div
+        className={
+          error && touched
+            ? "nhsuk-form-group nhsuk-form-group--error"
+            : "nhsuk-form-group"
+        }
       >
-        <option value="">-- Please select--</option>
-        {options
-          ? options.map((o: { value: string; label: string }) => (
-              <option key={o.label} value={o.value}>
-                {o.label}
-              </option>
-            ))
-          : null}
-      </Field>
+        <Select
+          id={props.id || props.name}
+          onBlur={() => {
+            helpers.setTouched(true);
+          }}
+          {...field}
+          {...props}
+          error={error && touched ? error : ""}
+          label={props.label}
+        >
+          <Select.Option value="">-- Please select --</Select.Option>
+          {props.options
+            ? props.options.map((option: { value: string; label: string }) => (
+                <Select.Option key={option.label} value={option.value}>
+                  {option.label}
+                </Select.Option>
+              ))
+            : null}
+        </Select>
+        <InputFooterLabel label={props.footer || ""} />
+      </div>
     </>
   );
 };
 
-export default SelectInputField;
+export default connect(SelectInputField);

--- a/src/components/forms/TextInputField.tsx
+++ b/src/components/forms/TextInputField.tsx
@@ -15,11 +15,12 @@ interface Props {
 }
 
 const TextInputField: FunctionComponent<Props> = props => {
-  const [field, { error, touched }] = useField({
-    name: props.name,
-    type: props.name
-  });
+  const [field, { error, touched }] = useField(props);
   const FormElement = props.rows ? Textarea : Input;
+
+  const setFieldWidth = (width: number) => {
+    return width < 20 ? 20 : Math.floor(width / 10) * 10;
+  };
 
   return (
     <>
@@ -31,10 +32,14 @@ const TextInputField: FunctionComponent<Props> = props => {
         }
       >
         <FormElement
-          width={props.width || 20}
+          width={
+            field.value ? props.width || setFieldWidth(field.value.length) : 20
+          }
           error={error && touched ? error : ""}
           id={props.id || props.name}
-          {...field}
+          onBlur={field.onBlur}
+          onChange={field.onChange}
+          value={field.value}
           {...props}
         />
         <InputFooterLabel label={props.footer || ""} />

--- a/src/components/forms/TextInputField.tsx
+++ b/src/components/forms/TextInputField.tsx
@@ -1,14 +1,46 @@
-import React from "react";
-import { Field } from "formik";
-import { Label } from "nhsuk-react-components";
+import React, { FunctionComponent } from "react";
+import { useField, connect } from "formik";
+import { Input, Textarea } from "nhsuk-react-components";
+import InputFooterLabel from "./InputFooterLabel";
+interface Props {
+  name: string;
+  label: string;
+  id?: string;
+  placeholder?: string;
+  rows?: number;
+  hint?: string;
+  width?: any;
+  footer?: any;
+  type?: string;
+}
 
-const TextInputField: React.FC<any> = ({ label, ...field }) => {
+const TextInputField: FunctionComponent<Props> = props => {
+  const [field, { error, touched }] = useField({
+    name: props.name,
+    type: props.name
+  });
+  const FormElement = props.rows ? Textarea : Input;
+
   return (
     <>
-      {label && label !== "" ? <Label>{label}</Label> : null}
-      <Field className="nhsuk-input" {...field} style={{ marginBottom: 10 }} />
+      <div
+        className={
+          error && touched
+            ? "nhsuk-form-group nhsuk-form-group--error"
+            : "nhsuk-form-group"
+        }
+      >
+        <FormElement
+          width={props.width || 20}
+          error={error && touched ? error : ""}
+          id={props.id || props.name}
+          {...field}
+          {...props}
+        />
+        <InputFooterLabel label={props.footer || ""} />
+      </div>
     </>
   );
 };
 
-export default TextInputField;
+export default connect(TextInputField);

--- a/src/components/forms/__test__/InputFootereLabel.text.tsx
+++ b/src/components/forms/__test__/InputFootereLabel.text.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import InputFooterLabel from "../InputFooterLabel";
+import { shallow } from "enzyme";
+
+describe("InputFooterLabel", () => {
+  it("renders without crashing", () => {
+    shallow(<InputFooterLabel label="Input footer label" />);
+  });
+});

--- a/src/components/forms/__test__/SelectInputField.test.tsx
+++ b/src/components/forms/__test__/SelectInputField.test.tsx
@@ -4,6 +4,8 @@ import { shallow } from "enzyme";
 
 describe("SelectInputField", () => {
   it("renders without crashing", () => {
-    shallow(<SelectInputField />);
+    shallow(
+      <SelectInputField name="selectInputField" label="Select input field" />
+    );
   });
 });

--- a/src/components/forms/__test__/TextInputField.test.tsx
+++ b/src/components/forms/__test__/TextInputField.test.tsx
@@ -4,6 +4,6 @@ import { shallow } from "enzyme";
 
 describe("TextInputField", () => {
   it("renders without crashing", () => {
-    shallow(<TextInputField />);
+    shallow(<TextInputField name="TextInputField" label="Text Input Field" />);
   });
 });

--- a/src/components/forms/formr-part-a/Create.tsx
+++ b/src/components/forms/formr-part-a/Create.tsx
@@ -130,9 +130,7 @@ class Create extends React.PureComponent<ConnectedProps<typeof connector>> {
                   {values.immigrationStatus === "Other" ? (
                     <TextInputField
                       name="otherImmigrationStatus"
-                      onSubmit={() =>
-                        setFieldValue("immigrationStatus", "Other")
-                      }
+                      label="Other"
                       placeholder="Please add your 'Other' immigration status"
                     />
                   ) : null}
@@ -156,10 +154,26 @@ class Create extends React.PureComponent<ConnectedProps<typeof connector>> {
                     name="address1"
                     placeholder="House number, name / road"
                   />
-                  <TextInputField name="address2" placeholder="district" />
-                  <TextInputField name="address3" placeholder="town or city" />
-                  <TextInputField name="address4" placeholder="country" />
-                  <TextInputField name="postCode" placeholder="postcode" />
+                  <TextInputField
+                    label="District"
+                    name="address2"
+                    placeholder="district"
+                  />
+                  <TextInputField
+                    label="Town or city"
+                    name="address3"
+                    placeholder="town or city"
+                  />
+                  <TextInputField
+                    label="Country"
+                    name="address4"
+                    placeholder="country"
+                  />
+                  <TextInputField
+                    label="Postcode"
+                    name="postCode"
+                    placeholder="postcode"
+                  />
                   <TextInputField
                     label="Contact Telephone (landline)"
                     name="telephoneNumber"
@@ -246,8 +260,14 @@ class Create extends React.PureComponent<ConnectedProps<typeof connector>> {
                 </Fieldset>
 
                 {[...Object.values(errors)].length > 0 ? (
-                  <ErrorSummary>
-                    <h3>Check the following</h3>
+                  <ErrorSummary
+                    aria-labelledby="errorSummaryTitle"
+                    role="alert"
+                    tabIndex={-1}
+                  >
+                    <ErrorSummary.Title id="errorSummaryTitle">
+                      Check the following
+                    </ErrorSummary.Title>
                     {Object.values(errors).map((errorMsg, i) => (
                       <ErrorSummary.Item key={i}>{errorMsg}</ErrorSummary.Item>
                     ))}

--- a/src/components/forms/formr-part-b/Sections/Section1.tsx
+++ b/src/components/forms/formr-part-b/Sections/Section1.tsx
@@ -35,6 +35,7 @@ const Section1 = (props: any) => {
             <TextInputField
               label="Primary contact email address"
               name="email"
+              hint="For reasons of security and due to frequent systme failures with internet email accounts, you are strongly advised to provide an NHS.net email address."
             />
             <SelectInputField
               label="Current Deanery / HEE Local team"
@@ -69,8 +70,14 @@ const Section1 = (props: any) => {
           </Fieldset>
 
           {[...Object.values(errors)].length > 0 ? (
-            <ErrorSummary>
-              <h3>Check the following</h3>
+            <ErrorSummary
+              aria-labelledby="errorSummaryTitle"
+              role="alert"
+              tabIndex={-1}
+            >
+              <ErrorSummary.Title id="errorSummaryTitle">
+                Check the following
+              </ErrorSummary.Title>
               {Object.values(errors).map((errorMsg, i) => (
                 <ErrorSummary.Item key={i}>{errorMsg}</ErrorSummary.Item>
               ))}


### PR DESCRIPTION
TISNEW-4531

- Modified the existing components **TextInputField** and **SelectInputField** to include components from the NHS React library that support inline error messaging and hint text. https://nhsdigital.github.io/nhsuk-react-components/?path=/story/input--with-error-string

- Added option to render multi-line html textarea instead of input field by setting a rows property   

- Updated error summary in line with NHS React component to improve accessibility through improved labelling.

- Added new component, **InputFooterLabel** to allow insertion of additional text below the form field that supports html markup to allow for inclusion of links.

- Added missing label properties to the address form fields on formr part a.

- Added hint text to email form field on formr part b, advising on preference for NHS.net email addresses.  

- Updated version of nhsuk-react-components in package.json. **This package update is required in order to render the new components correctly.**

