### PR TITLE
Feature/profile page redesign

### DIFF
--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -6,7 +6,7 @@ import PersonalDetailsComponent from "./personal-details/PersonalDetailsComponen
 import Programmes from "./programmes/Programmes";
 import Placements from "./placements/Placements";
 import Loading from "../common/Loading";
-import { Fieldset } from "nhsuk-react-components";
+import { Fieldset, Details } from "nhsuk-react-components";
 import { TraineeProfileService } from "../../services/TraineeProfileService";
 
 const mapStateToProps = (state: RootState) => ({
@@ -38,13 +38,16 @@ class Profile extends React.PureComponent<profileProps> {
             <Fieldset>
               <Fieldset.Legend isPageHeading>Profile</Fieldset.Legend>
             </Fieldset>
-            <PersonalDetailsComponent
-              personalDetails={traineeProfile.personalDetails}
-            />
-            <Placements placements={traineeProfile.placements}></Placements>
-            <Programmes
-              programmeMemberships={traineeProfile.programmeMemberships}
-            ></Programmes>
+            <Details.ExpanderGroup>
+              <PersonalDetailsComponent
+                personalDetails={traineeProfile.personalDetails}
+              />
+              <Placements placements={traineeProfile.placements}></Placements>
+
+              <Programmes
+                programmeMemberships={traineeProfile.programmeMemberships}
+              ></Programmes>
+            </Details.ExpanderGroup>
           </div>
         )
       );

--- a/src/components/profile/personal-details/PersonalDetailsComponent.tsx
+++ b/src/components/profile/personal-details/PersonalDetailsComponent.tsx
@@ -1,12 +1,7 @@
 import React from "react";
 import { PersonalDetails } from "../../../models/PersonalDetails";
-import styles from "./PersonalDetailsComponent.module.scss";
-import { SummaryList } from "nhsuk-react-components";
-import ExpansionPanel from "@material-ui/core/ExpansionPanel";
-import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
-import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
+import { SummaryList, Details } from "nhsuk-react-components";
 import Typography from "@material-ui/core/Typography";
-import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import { makeStyles } from "@material-ui/core/styles";
 import { KeyValue } from "../../../models/KeyValue";
 import { DateUtilities } from "../../../utilities/DateUtilities";
@@ -62,52 +57,47 @@ const PersonalDetailsComponent: React.FC<IProps> = ({ personalDetails }) => {
     { label: "Visa Issued", value: personalDetails.visaIssued },
     { label: "Details/Number", value: personalDetails.detailsNumber }
   ];
-  return (
-    <section className={classes.sectionPadding}>
-      <ExpansionPanel defaultExpanded={false}>
-        <ExpansionPanelSummary
-          expandIcon={<ExpandMoreIcon />}
-          aria-controls="panel1a-content"
-          id="panel1a-header"
-        >
-          <div id="traineeName" className={styles.name}>
-            {fullName}
-          </div>
-        </ExpansionPanelSummary>
-        <ExpansionPanelDetails>
-          <SummaryList noBorder={true}>
-            {personalData.map(pd => (
-              <SummaryList.Row key={pd.label}>
-                <SummaryList.Key>{pd.label}</SummaryList.Key>
-                <SummaryList.Value>{pd.value}</SummaryList.Value>
-              </SummaryList.Row>
-            ))}
 
-            <SummaryList.Row>
-              <SummaryList.Key>Address</SummaryList.Key>
-              <SummaryList.Value>
-                <p>{personalDetails.address1}</p>
-                <p>{personalDetails.address2}</p>
-                <p>
-                  {personalDetails.address3}, {personalDetails.address4}
-                </p>
-                <p>{personalDetails.postCode}</p>
-              </SummaryList.Value>
+  return (
+    <Details expander>
+      <Details.Summary>Personal details</Details.Summary>
+      <Details.Text>
+        <SummaryList>
+          <SummaryList.Row>
+            <SummaryList.Key>Fullname</SummaryList.Key>
+            <SummaryList.Value>{fullName}</SummaryList.Value>
+          </SummaryList.Row>
+          {personalData.map(pd => (
+            <SummaryList.Row key={pd.label}>
+              <SummaryList.Key>{pd.label}</SummaryList.Key>
+              <SummaryList.Value>{pd.value}</SummaryList.Value>
             </SummaryList.Row>
-            <Typography className={classes.heading}>Sensitive data</Typography>
-            {sensitiveData.map(
-              sd =>
-                sd.value && (
-                  <SummaryList.Row key={sd.label}>
-                    <SummaryList.Key>{sd.label}</SummaryList.Key>
-                    <SummaryList.Value>{sd.value}</SummaryList.Value>
-                  </SummaryList.Row>
-                )
-            )}
-          </SummaryList>
-        </ExpansionPanelDetails>
-      </ExpansionPanel>
-    </section>
+          ))}
+
+          <SummaryList.Row>
+            <SummaryList.Key>Address</SummaryList.Key>
+            <SummaryList.Value>
+              <p>{personalDetails.address1}</p>
+              <p>{personalDetails.address2}</p>
+              <p>
+                {personalDetails.address3}, {personalDetails.address4}
+              </p>
+              <p>{personalDetails.postCode}</p>
+            </SummaryList.Value>
+          </SummaryList.Row>
+          <Typography className={classes.heading}>Sensitive data</Typography>
+          {sensitiveData.map(
+            sd =>
+              sd.value && (
+                <SummaryList.Row key={sd.label}>
+                  <SummaryList.Key>{sd.label}</SummaryList.Key>
+                  <SummaryList.Value>{sd.value}</SummaryList.Value>
+                </SummaryList.Row>
+              )
+          )}
+        </SummaryList>
+      </Details.Text>
+    </Details>
   );
 };
 

--- a/src/components/profile/personal-details/PersonalDetailsComponent.tsx
+++ b/src/components/profile/personal-details/PersonalDetailsComponent.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import { PersonalDetails } from "../../../models/PersonalDetails";
 import { SummaryList, Details } from "nhsuk-react-components";
-import Typography from "@material-ui/core/Typography";
-import { makeStyles } from "@material-ui/core/styles";
 import { KeyValue } from "../../../models/KeyValue";
 import { DateUtilities } from "../../../utilities/DateUtilities";
 
@@ -10,23 +8,7 @@ interface IProps {
   personalDetails: PersonalDetails | null;
 }
 
-const useStyles = makeStyles(theme => ({
-  root: {
-    width: "100%"
-  },
-  heading: {
-    fontSize: theme.typography.pxToRem(22),
-    fontWeight: theme.typography.fontWeightBold,
-    margin: "5px 0"
-  },
-  sectionPadding: {
-    padding: theme.typography.pxToRem(20)
-  }
-}));
-
 const PersonalDetailsComponent: React.FC<IProps> = ({ personalDetails }) => {
-  const classes = useStyles();
-
   if (!personalDetails) {
     return <div>Failed to laod data.</div>;
   }
@@ -85,7 +67,9 @@ const PersonalDetailsComponent: React.FC<IProps> = ({ personalDetails }) => {
               <p>{personalDetails.postCode}</p>
             </SummaryList.Value>
           </SummaryList.Row>
-          <Typography className={classes.heading}>Sensitive data</Typography>
+          <div className="nhsuk-heading-m nhsuk-u-margin-top-4">
+            Sensitive data
+          </div>
           {sensitiveData.map(
             sd =>
               sd.value && (

--- a/src/components/profile/placements/PlacementPanel.tsx
+++ b/src/components/profile/placements/PlacementPanel.tsx
@@ -9,6 +9,7 @@ interface IPlacementPanelProps {
 
 export const PlacementPanel = (props: IPlacementPanelProps) => {
   const data = props.placement;
+
   return (
     <>
       <SummaryList>
@@ -18,7 +19,9 @@ export const PlacementPanel = (props: IPlacementPanelProps) => {
         </SummaryList.Row>
 
         <SummaryList.Row>
-          <SummaryList.Key>Starts</SummaryList.Key>
+          <SummaryList.Key>
+            <span className="noWrap">Starts</span>
+          </SummaryList.Key>
           <SummaryList.Value>
             {DateUtilities.ToLocalDate(data.startDate)}
           </SummaryList.Value>
@@ -31,7 +34,9 @@ export const PlacementPanel = (props: IPlacementPanelProps) => {
           </SummaryList.Value>
         </SummaryList.Row>
         <SummaryList.Row>
-          <SummaryList.Key>Specialty</SummaryList.Key>
+          <SummaryList.Key>
+            <span className="noWrap">Specialty</span>
+          </SummaryList.Key>
           <SummaryList.Value>{data.specialty}</SummaryList.Value>
         </SummaryList.Row>
       </SummaryList>

--- a/src/components/profile/placements/PlacementPanel.tsx
+++ b/src/components/profile/placements/PlacementPanel.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Placement } from "../../../models/Placement";
-import styles from "./Placements.module.scss";
+import { SummaryList } from "nhsuk-react-components";
 import { DateUtilities } from "../../../utilities/DateUtilities";
 
 interface IPlacementPanelProps {
@@ -10,25 +10,32 @@ interface IPlacementPanelProps {
 export const PlacementPanel = (props: IPlacementPanelProps) => {
   const data = props.placement;
   return (
-    <div id="placementContainer" className={styles.container}>
-      <div>
-        <b>{data.status.charAt(0) + data.status.slice(1).toLowerCase()}</b>
-        <p>{data.site}</p>
-      </div>
+    <>
+      <SummaryList>
+        <SummaryList.Row>
+          <SummaryList.Key>Site</SummaryList.Key>
+          <SummaryList.Value>{data.site}</SummaryList.Value>
+        </SummaryList.Row>
 
-      <div className={styles.grid}>
-        <div>
-          <b>Starts: </b> <p>{DateUtilities.ToLocalDate(data.startDate)}</p>
-        </div>
-        <div className={styles.followingField}>
-          <b>Ends: </b> <p>{DateUtilities.ToLocalDate(data.endDate)}</p>
-        </div>
-      </div>
+        <SummaryList.Row>
+          <SummaryList.Key>Starts</SummaryList.Key>
+          <SummaryList.Value>
+            {DateUtilities.ToLocalDate(data.startDate)}
+          </SummaryList.Value>
+        </SummaryList.Row>
 
-      <div>
-        <b>Specialty: </b> <p>{data.specialty}</p>
-      </div>
-    </div>
+        <SummaryList.Row>
+          <SummaryList.Key>Ends</SummaryList.Key>
+          <SummaryList.Value>
+            {DateUtilities.ToLocalDate(data.endDate)}
+          </SummaryList.Value>
+        </SummaryList.Row>
+        <SummaryList.Row>
+          <SummaryList.Key>Specialty</SummaryList.Key>
+          <SummaryList.Value>{data.specialty}</SummaryList.Value>
+        </SummaryList.Row>
+      </SummaryList>
+    </>
   );
 };
 

--- a/src/components/profile/placements/PlacementPanel.tsx
+++ b/src/components/profile/placements/PlacementPanel.tsx
@@ -11,36 +11,34 @@ export const PlacementPanel = (props: IPlacementPanelProps) => {
   const data = props.placement;
 
   return (
-    <>
-      <SummaryList>
-        <SummaryList.Row>
-          <SummaryList.Key>Site</SummaryList.Key>
-          <SummaryList.Value>{data.site}</SummaryList.Value>
-        </SummaryList.Row>
+    <SummaryList>
+      <SummaryList.Row>
+        <SummaryList.Key>Site</SummaryList.Key>
+        <SummaryList.Value>{data.site}</SummaryList.Value>
+      </SummaryList.Row>
 
-        <SummaryList.Row>
-          <SummaryList.Key>
-            <span className="noWrap">Starts</span>
-          </SummaryList.Key>
-          <SummaryList.Value>
-            {DateUtilities.ToLocalDate(data.startDate)}
-          </SummaryList.Value>
-        </SummaryList.Row>
+      <SummaryList.Row>
+        <SummaryList.Key>
+          <span className="noWrap">Starts</span>
+        </SummaryList.Key>
+        <SummaryList.Value>
+          {DateUtilities.ToLocalDate(data.startDate)}
+        </SummaryList.Value>
+      </SummaryList.Row>
 
-        <SummaryList.Row>
-          <SummaryList.Key>Ends</SummaryList.Key>
-          <SummaryList.Value>
-            {DateUtilities.ToLocalDate(data.endDate)}
-          </SummaryList.Value>
-        </SummaryList.Row>
-        <SummaryList.Row>
-          <SummaryList.Key>
-            <span className="noWrap">Specialty</span>
-          </SummaryList.Key>
-          <SummaryList.Value>{data.specialty}</SummaryList.Value>
-        </SummaryList.Row>
-      </SummaryList>
-    </>
+      <SummaryList.Row>
+        <SummaryList.Key>Ends</SummaryList.Key>
+        <SummaryList.Value>
+          {DateUtilities.ToLocalDate(data.endDate)}
+        </SummaryList.Value>
+      </SummaryList.Row>
+      <SummaryList.Row>
+        <SummaryList.Key>
+          <span className="noWrap">Specialty</span>
+        </SummaryList.Key>
+        <SummaryList.Value>{data.specialty}</SummaryList.Value>
+      </SummaryList.Row>
+    </SummaryList>
   );
 };
 

--- a/src/components/profile/placements/Placements.module.scss
+++ b/src/components/profile/placements/Placements.module.scss
@@ -1,1 +1,28 @@
 @import "../../Common.module.scss";
+:global .nhsuk-grid-column-one-third,
+:global .nhsuk-grid-column-one-half {
+  .nhsuk-summary-list {
+    padding: 10px;
+    background-color: #f0f4f5;
+    .nhsuk-summary-list__row {
+      width: 100%;
+      &:last-child {
+        dt,
+        dd {
+          border-bottom: 0;
+        }
+      }
+      @media only screen and (min-width: 769px) {
+        font-size: 0.8em;
+      }
+    }
+  }
+}
+
+:global .nhsuk-grid-column-one-half {
+  .nhsuk-summary-list__row {
+    @media only screen and (min-width: 769px) {
+      font-size: 0.9em;
+    }
+  }
+}

--- a/src/components/profile/placements/Placements.tsx
+++ b/src/components/profile/placements/Placements.tsx
@@ -1,64 +1,31 @@
 import React from "react";
-import Divider from "@material-ui/core/Divider";
-import ExpansionPanel from "@material-ui/core/ExpansionPanel";
-import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
-import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
-import Typography from "@material-ui/core/Typography";
-import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import { Details } from "nhsuk-react-components";
 import { PlacementPanel } from "./PlacementPanel";
 import { Placement } from "../../../models/Placement";
-import { makeStyles } from "@material-ui/core/styles";
 
 interface IPlacementProps {
   placements: Placement[];
 }
 
-const useStyles = makeStyles(theme => ({
-  root: {
-    width: "100%"
-  },
-  heading: {
-    fontSize: theme.typography.pxToRem(22),
-    fontWeight: theme.typography.fontWeightBold,
-    margin: "0px"
-  },
-  sectionPadding: {
-    padding: theme.typography.pxToRem(20)
-  }
-}));
-
 const Placements: React.FC<IPlacementProps> = ({ placements }) => {
-  const classes = useStyles();
   return (
     placements && (
-      <section className={classes.sectionPadding}>
-        <Divider />
-        <div>
-          <ExpansionPanel defaultExpanded={true}>
-            <ExpansionPanelSummary
-              expandIcon={<ExpandMoreIcon />}
-              aria-controls="panel1a-content"
-              id="panel1a-header"
-            >
-              <Typography className={classes.heading}>Placements</Typography>
-            </ExpansionPanelSummary>
-            <ExpansionPanelDetails>
-              <div className={classes.root}>
-                {placements.length === 0 ? (
-                  <div>You are not assigned to any placement</div>
-                ) : (
-                  placements.map(
-                    (
-                      placement: Placement,
-                      index: string | number | undefined
-                    ) => <PlacementPanel key={index} placement={placement} />
-                  )
-                )}
-              </div>
-            </ExpansionPanelDetails>
-          </ExpansionPanel>
-        </div>
-      </section>
+      <>
+        <Details expander>
+          <Details.Summary>Placements</Details.Summary>
+          <Details.Text>
+            {placements.length === 0 ? (
+              <div>You are not assigned to any placement</div>
+            ) : (
+              placements.map(
+                (placement: Placement, index: string | number | undefined) => (
+                  <PlacementPanel key={index} placement={placement} />
+                )
+              )
+            )}
+          </Details.Text>
+        </Details>
+      </>
     )
   );
 };

--- a/src/components/profile/placements/Placements.tsx
+++ b/src/components/profile/placements/Placements.tsx
@@ -16,29 +16,24 @@ const Placements: React.FC<IPlacementProps> = ({ placements }) => {
 
   return (
     placements && (
-      <>
-        <Details expander>
-          <Details.Summary>Placements</Details.Summary>
-          <Details.Text>
-            <Row className={styles.placementRow}>
-              {placements.length === 0 ? (
-                <div>You are not assigned to any placement</div>
-              ) : (
-                placements.map(
-                  (
-                    placement: Placement,
-                    index: number | string | undefined
-                  ) => (
-                    <Col key={index} width={columnWidth}>
-                      <PlacementPanel key={index} placement={placement} />
-                    </Col>
-                  )
+      <Details expander>
+        <Details.Summary>Placements</Details.Summary>
+        <Details.Text>
+          <Row className={styles.placementRow}>
+            {placements.length === 0 ? (
+              <div>You are not assigned to any placement</div>
+            ) : (
+              placements.map(
+                (placement: Placement, index: number | string | undefined) => (
+                  <Col key={index} width={columnWidth}>
+                    <PlacementPanel key={index} placement={placement} />
+                  </Col>
                 )
-              )}
-            </Row>
-          </Details.Text>
-        </Details>
-      </>
+              )
+            )}
+          </Row>
+        </Details.Text>
+      </Details>
     )
   );
 };

--- a/src/components/profile/placements/Placements.tsx
+++ b/src/components/profile/placements/Placements.tsx
@@ -1,28 +1,41 @@
 import React from "react";
-import { Details } from "nhsuk-react-components";
+import { Details, Row, Col } from "nhsuk-react-components";
 import { PlacementPanel } from "./PlacementPanel";
 import { Placement } from "../../../models/Placement";
+import styles from "./Placements.module.scss";
 
 interface IPlacementProps {
   placements: Placement[];
 }
 
 const Placements: React.FC<IPlacementProps> = ({ placements }) => {
+  const columnWidths: any[] = ["full", "full", "one-half", "one-third"];
+  let columnWidth = columnWidths[placements.length]
+    ? columnWidths[placements.length]
+    : "one-third";
+
   return (
     placements && (
       <>
         <Details expander>
           <Details.Summary>Placements</Details.Summary>
           <Details.Text>
-            {placements.length === 0 ? (
-              <div>You are not assigned to any placement</div>
-            ) : (
-              placements.map(
-                (placement: Placement, index: string | number | undefined) => (
-                  <PlacementPanel key={index} placement={placement} />
+            <Row className={styles.placementRow}>
+              {placements.length === 0 ? (
+                <div>You are not assigned to any placement</div>
+              ) : (
+                placements.map(
+                  (
+                    placement: Placement,
+                    index: number | string | undefined
+                  ) => (
+                    <Col key={index} width={columnWidth}>
+                      <PlacementPanel key={index} placement={placement} />
+                    </Col>
+                  )
                 )
-              )
-            )}
+              )}
+            </Row>
           </Details.Text>
         </Details>
       </>

--- a/src/components/profile/programmes/ProgrammePanel.tsx
+++ b/src/components/profile/programmes/ProgrammePanel.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ProgrammeMembership } from "../../../models/ProgrammeMembership";
-import styles from "./Programmes.module.scss";
+import { SummaryList } from "nhsuk-react-components";
 
 interface IProgrammePanelProps {
   programmeMembership: ProgrammeMembership;
@@ -9,33 +9,43 @@ interface IProgrammePanelProps {
 export const ProgrammePanel = (props: IProgrammePanelProps) => {
   const data = props.programmeMembership;
   return (
-    <div id="programmeContainer" className={styles.container}>
-      <div className={styles.grid}>
-        <div>
-          <b>Number:</b>
-          <p>{data.programmeNumber}</p>
-        </div>
-        <div className={styles.followingField}>
-          <b>Status: </b>
-          <p>{data.status.charAt(0) + data.status.slice(1).toLowerCase()}</p>
-        </div>
-      </div>
+    <>
+      <SummaryList>
+        <SummaryList.Row>
+          <SummaryList.Key>Number</SummaryList.Key>
+          <SummaryList.Value>{data.programmeNumber}</SummaryList.Value>
+        </SummaryList.Row>
 
-      <div>
-        <b>Name: </b> <p>{data.programmeName}</p>
-      </div>
-      <div>
-        <b>Owner: </b> <p>{data.managingDeanery}</p>
-      </div>
-      <div>
-        <b>Curricula:</b>{" "}
-        {data.curricula.length === 0
-          ? "N/A"
-          : data.curricula.map((c, index) => (
-              <span key={index}>{c.curriculumName}</span>
-            ))}
-      </div>
-    </div>
+        <SummaryList.Row>
+          <SummaryList.Key>Status</SummaryList.Key>
+          <SummaryList.Value>
+            {data.status.charAt(0) + data.status.slice(1).toLowerCase()}
+          </SummaryList.Value>
+        </SummaryList.Row>
+
+        <SummaryList.Row>
+          <SummaryList.Key>Name</SummaryList.Key>
+          <SummaryList.Value>{data.programmeName}</SummaryList.Value>
+        </SummaryList.Row>
+
+        <SummaryList.Row>
+          <SummaryList.Key>Owner</SummaryList.Key>
+          <SummaryList.Value>{data.managingDeanery}</SummaryList.Value>
+        </SummaryList.Row>
+
+        <SummaryList.Row>
+          <SummaryList.Key>Curricula</SummaryList.Key>
+          <SummaryList.Value>
+            {" "}
+            {data.curricula.length === 0
+              ? "N/A"
+              : data.curricula.map((c, index) => (
+                  <span key={index}>{c.curriculumName}</span>
+                ))}
+          </SummaryList.Value>
+        </SummaryList.Row>
+      </SummaryList>
+    </>
   );
 };
 

--- a/src/components/profile/programmes/ProgrammePanel.tsx
+++ b/src/components/profile/programmes/ProgrammePanel.tsx
@@ -9,43 +9,41 @@ interface IProgrammePanelProps {
 export const ProgrammePanel = (props: IProgrammePanelProps) => {
   const data = props.programmeMembership;
   return (
-    <>
-      <SummaryList>
-        <SummaryList.Row>
-          <SummaryList.Key>Number</SummaryList.Key>
-          <SummaryList.Value>{data.programmeNumber}</SummaryList.Value>
-        </SummaryList.Row>
+    <SummaryList>
+      <SummaryList.Row>
+        <SummaryList.Key>Number</SummaryList.Key>
+        <SummaryList.Value>{data.programmeNumber}</SummaryList.Value>
+      </SummaryList.Row>
 
-        <SummaryList.Row>
-          <SummaryList.Key>Status</SummaryList.Key>
-          <SummaryList.Value>
-            {data.status.charAt(0) + data.status.slice(1).toLowerCase()}
-          </SummaryList.Value>
-        </SummaryList.Row>
+      <SummaryList.Row>
+        <SummaryList.Key>Status</SummaryList.Key>
+        <SummaryList.Value>
+          {data.status.charAt(0) + data.status.slice(1).toLowerCase()}
+        </SummaryList.Value>
+      </SummaryList.Row>
 
-        <SummaryList.Row>
-          <SummaryList.Key>Name</SummaryList.Key>
-          <SummaryList.Value>{data.programmeName}</SummaryList.Value>
-        </SummaryList.Row>
+      <SummaryList.Row>
+        <SummaryList.Key>Name</SummaryList.Key>
+        <SummaryList.Value>{data.programmeName}</SummaryList.Value>
+      </SummaryList.Row>
 
-        <SummaryList.Row>
-          <SummaryList.Key>Owner</SummaryList.Key>
-          <SummaryList.Value>{data.managingDeanery}</SummaryList.Value>
-        </SummaryList.Row>
+      <SummaryList.Row>
+        <SummaryList.Key>Owner</SummaryList.Key>
+        <SummaryList.Value>{data.managingDeanery}</SummaryList.Value>
+      </SummaryList.Row>
 
-        <SummaryList.Row>
-          <SummaryList.Key>Curricula</SummaryList.Key>
-          <SummaryList.Value>
-            {" "}
-            {data.curricula.length === 0
-              ? "N/A"
-              : data.curricula.map((c, index) => (
-                  <span key={index}>{c.curriculumName}</span>
-                ))}
-          </SummaryList.Value>
-        </SummaryList.Row>
-      </SummaryList>
-    </>
+      <SummaryList.Row>
+        <SummaryList.Key>Curricula</SummaryList.Key>
+        <SummaryList.Value>
+          {" "}
+          {data.curricula.length === 0
+            ? "N/A"
+            : data.curricula.map((c, index) => (
+                <span key={index}>{c.curriculumName}</span>
+              ))}
+        </SummaryList.Value>
+      </SummaryList.Row>
+    </SummaryList>
   );
 };
 

--- a/src/components/profile/programmes/Programmes.tsx
+++ b/src/components/profile/programmes/Programmes.tsx
@@ -1,11 +1,6 @@
 import React from "react";
-import Divider from "@material-ui/core/Divider";
 import { makeStyles } from "@material-ui/core/styles";
-import ExpansionPanel from "@material-ui/core/ExpansionPanel";
-import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
-import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
-import Typography from "@material-ui/core/Typography";
-import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import { Details } from "nhsuk-react-components";
 import { ProgrammePanel } from "./ProgrammePanel";
 import { ProgrammeMembership } from "../../../models/ProgrammeMembership";
 
@@ -31,39 +26,30 @@ const Programmes: React.FC<IProgramProps> = ({ programmeMemberships }) => {
   const classes = useStyles();
   return (
     programmeMemberships && (
-      <section className={classes.sectionPadding}>
-        <Divider />
-        <div>
-          <ExpansionPanel defaultExpanded={true}>
-            <ExpansionPanelSummary
-              expandIcon={<ExpandMoreIcon />}
-              aria-controls="panel1a-content"
-              id="panel1a-header"
-            >
-              <Typography className={classes.heading}>Programmes</Typography>
-            </ExpansionPanelSummary>
-            <ExpansionPanelDetails>
-              <div className={classes.root}>
-                {programmeMemberships.length === 0 ? (
-                  <div>You are not assigned to any programme</div>
-                ) : (
-                  programmeMemberships.map(
-                    (
-                      programmeMembership: ProgrammeMembership,
-                      index: string | number | undefined
-                    ) => (
-                      <ProgrammePanel
-                        key={index}
-                        programmeMembership={programmeMembership}
-                      />
-                    )
+      <>
+        <Details expander>
+          <Details.Summary>Programmes</Details.Summary>
+          <Details.Text>
+            <div className={classes.root}>
+              {programmeMemberships.length === 0 ? (
+                <div>You are not assigned to any programme</div>
+              ) : (
+                programmeMemberships.map(
+                  (
+                    programmeMembership: ProgrammeMembership,
+                    index: string | number | undefined
+                  ) => (
+                    <ProgrammePanel
+                      key={index}
+                      programmeMembership={programmeMembership}
+                    />
                   )
-                )}
-              </div>
-            </ExpansionPanelDetails>
-          </ExpansionPanel>
-        </div>
-      </section>
+                )
+              )}
+            </div>
+          </Details.Text>
+        </Details>
+      </>
     )
   );
 };

--- a/src/components/profile/programmes/Programmes.tsx
+++ b/src/components/profile/programmes/Programmes.tsx
@@ -26,30 +26,28 @@ const Programmes: React.FC<IProgramProps> = ({ programmeMemberships }) => {
   const classes = useStyles();
   return (
     programmeMemberships && (
-      <>
-        <Details expander>
-          <Details.Summary>Programmes</Details.Summary>
-          <Details.Text>
-            <div className={classes.root}>
-              {programmeMemberships.length === 0 ? (
-                <div>You are not assigned to any programme</div>
-              ) : (
-                programmeMemberships.map(
-                  (
-                    programmeMembership: ProgrammeMembership,
-                    index: string | number | undefined
-                  ) => (
-                    <ProgrammePanel
-                      key={index}
-                      programmeMembership={programmeMembership}
-                    />
-                  )
+      <Details expander>
+        <Details.Summary>Programmes</Details.Summary>
+        <Details.Text>
+          <div className={classes.root}>
+            {programmeMemberships.length === 0 ? (
+              <div>You are not assigned to any programme</div>
+            ) : (
+              programmeMemberships.map(
+                (
+                  programmeMembership: ProgrammeMembership,
+                  index: string | number | undefined
+                ) => (
+                  <ProgrammePanel
+                    key={index}
+                    programmeMembership={programmeMembership}
+                  />
                 )
-              )}
-            </div>
-          </Details.Text>
-        </Details>
-      </>
+              )
+            )}
+          </div>
+        </Details.Text>
+      </Details>
     )
   );
 };

--- a/src/index.scss
+++ b/src/index.scss
@@ -47,6 +47,17 @@ code {
   border-top: transparent;
 }
 
+fieldset {
+  border: 0;
+  padding: 0;
+  margin: 0;
+  min-width: 0;
+}
+
+.nhsuk-pagination__link {
+  cursor: pointer;
+}
+
 @media only screen and (max-width: 600px) {
   .MuiTypography-h5 {
     display: none;

--- a/src/index.scss
+++ b/src/index.scss
@@ -58,6 +58,10 @@ fieldset {
   cursor: pointer;
 }
 
+.noWrap {
+  white-space: nowrap;
+}
+
 @media only screen and (max-width: 600px) {
   .MuiTypography-h5 {
     display: none;


### PR DESCRIPTION
- Replace expandable component with equivalent from nhs react component library for the profile details, placements and programme sections.

- Add grid layout from nhs react component library to placements section to display placements in columns. 1 placement = 1 column, 2 placements = 2 columns, 3 or more placements = 3 columns.  

- Add summary list from nhs react component library to list data from each section to maintain consistency with other sections. 

- Fix fieldset that was extending forms beyond the viewport on small screens

- Change cursor to pointer for prev/next page links in formr part b
 