### PR TITLE
Add sections 3 & 4 to COVID Declaration form

### DIFF
--- a/cypress/integration/formr-a/formr-a.spec.ts
+++ b/cypress/integration/formr-a/formr-a.spec.ts
@@ -125,7 +125,7 @@ describe("Form R (Part A)", () => {
           //-- Declarations section --
           cy.get("#cctSpecialty1").should("not.be.visible");
           cy.get("#cctSpecialty2").should("not.be.visible");
-          cy.get("[data-cy=radio-0]").click();
+          cy.get("[data-cy=declarationType0]").click();
           cy.get("#cctSpecialty1").should("be.visible");
           cy.get("#cctSpecialty2").should("be.visible");
 
@@ -257,7 +257,7 @@ describe("Form R (Part A)", () => {
           //-- Declarations section --
           cy.get("#cctSpecialty1").should("not.be.visible");
           cy.get("#cctSpecialty2").should("not.be.visible");
-          cy.get("[data-cy=radio-0]").click();
+          cy.get("[data-cy=declarationType0]").click();
           cy.get("#cctSpecialty1").should("be.visible");
           cy.get("#cctSpecialty2").should("be.visible");
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -98,7 +98,7 @@ Cypress.Commands.add(
       .should("be.visible")
       .should("have.value", "traineeui.tester@hee.nhs.uk");
 
-    cy.get("[data-cy=radio-0]").should("be.checked");
+    cy.get("[data-cy=declarationType0]").should("be.checked");
 
     cy.get("#programmeSpecialty")
       .should("be.visible")
@@ -394,6 +394,30 @@ Cypress.Commands.add("checkAndFillCovidSection", () => {
   cy.get("[data-cy='covidDeclarationDto.discussWithSomeoneChecked0']")
     .should("be.visible")
     .check();
+
+  cy.get("[data-cy='covidDeclarationDto.haveChangesToPlacement0']")
+    .should("be.visible")
+    .check();
+
+  cy.get("[data-cy='covidDeclarationDto.changeCircumstances']")
+    .should("be.visible")
+    .select("Other")
+    .should("have.value", "Other");
+  cy.get("[data-cy='covidDeclarationDto.changeCircumstanceOther']")
+    .should("be.visible")
+    .type("Other circumstance of change");
+  cy.get("[data-cy='covidDeclarationDto.howPlacementAdjusted']")
+    .should("be.visible")
+    .type("How your placement was adjusted");
+  cy.get("[data-cy='covidDeclarationDto.educationSupervisorName']")
+    .should("be.visible")
+    .type("Education Supervisor Name");
+  cy.get("[data-cy='covidDeclarationDto.educationSupervisorEmail']").should(
+    "be.visible"
+  );
+  cy.get("[data-cy='covidDeclarationDto.educationSupervisorEmail']").type(
+    "Education@Supervisor.Name"
+  );
 });
 
 Cypress.Commands.add("addWorkPanel", (startDate, endDate) => {

--- a/src/components/forms/SelectInputField.tsx
+++ b/src/components/forms/SelectInputField.tsx
@@ -15,6 +15,7 @@ interface Props {
 
 const SelectInputField: React.FC<Props> = props => {
   const [field, { error }, helpers] = useField(props);
+  const { name, id, label, onChange, hint, footer } = props;
   return (
     <>
       <div
@@ -25,17 +26,17 @@ const SelectInputField: React.FC<Props> = props => {
         }
       >
         <Select
-          name={props.name}
-          id={props.id || props.name}
+          name={name}
+          id={id || name}
           onBlur={() => {
             helpers.setTouched(true);
           }}
           error={error || ""}
-          label={props.label}
-          onChange={props.onChange ? props.onChange : field.onChange}
-          hint={props.hint}
+          label={label}
+          onChange={onChange ? onChange : field.onChange}
+          hint={hint}
           value={field.value || ""}
-          data-cy={props.name}
+          data-cy={name}
         >
           <Select.Option value="">-- Please select --</Select.Option>
           {props.options
@@ -46,7 +47,7 @@ const SelectInputField: React.FC<Props> = props => {
               ))
             : null}
         </Select>
-        <InputFooterLabel label={props.footer || ""} />
+        <InputFooterLabel label={footer || ""} />
       </div>
     </>
   );

--- a/src/components/forms/SelectInputField.tsx
+++ b/src/components/forms/SelectInputField.tsx
@@ -10,6 +10,7 @@ interface Props {
   hint?: string;
   options?: any[];
   footer?: any;
+  onChange?: any;
 }
 
 const SelectInputField: React.FC<Props> = props => {
@@ -31,7 +32,7 @@ const SelectInputField: React.FC<Props> = props => {
           }}
           error={error || ""}
           label={props.label}
-          onChange={field.onChange}
+          onChange={props.onChange ? props.onChange : field.onChange}
           hint={props.hint}
           value={field.value || ""}
           data-cy={props.name}

--- a/src/components/forms/StringValidationSchema.ts
+++ b/src/components/forms/StringValidationSchema.ts
@@ -6,7 +6,10 @@ export const StringValidationSchema = (
 ) =>
   yup
     .string()
-    .transform(value => (value as string).trim())
+    .nullable()
+    .transform(value => {
+      if (value) return (value as string).trim();
+    })
     .min(1)
     .max(maxLength, `${fieldName} must be shorter than ${maxLength} characters`)
     .required(`${fieldName} is required`);

--- a/src/components/forms/formr-part-a/Create.tsx
+++ b/src/components/forms/formr-part-a/Create.tsx
@@ -129,7 +129,7 @@ class Create extends React.PureComponent<CreateProps> {
           validationSchema={ValidationSchema}
           onSubmit={values => this.handleSubmit(values)}
         >
-          {({ values, errors, setFieldValue }) => (
+          {({ values, errors }) => (
             <Form>
               <WarningCallout label="Important">
                 <p>

--- a/src/components/forms/formr-part-b/Sections/CovidDeclaration.tsx
+++ b/src/components/forms/formr-part-b/Sections/CovidDeclaration.tsx
@@ -60,7 +60,7 @@ const CovidDeclaration: FunctionComponent<SectionProps> = (
           nextSection(values);
         }}
       >
-        {({ values, setFieldValue, setFieldTouched, handleSubmit }) => (
+        {({ values, handleSubmit, setFieldValue }) => (
           <Form>
             <ScrollTo />
             <Fieldset
@@ -88,27 +88,8 @@ const CovidDeclaration: FunctionComponent<SectionProps> = (
                   name="haveCovidDeclarations"
                   type="radios"
                   items={YES_NO_OPTIONS}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    setTimeout(() =>
-                      setFieldTouched("haveCovidDeclarations", true)
-                    );
-                    if (BooleanUtilities.ToBoolean(e.target.value)) {
-                      setFieldValue("covidDeclarationDto", {
-                        selfRateForCovid: "",
-                        reasonOfSelfRate: "",
-                        otherInformationForPanel: "",
-                        discussWithSupervisorChecked: false,
-                        discussWithSomeoneChecked: false,
-                        haveChangesToPlacement: "",
-                        changeCircumstances: "",
-                        changeCircumstanceOther: "",
-                        howPlacementAdjusted: "",
-                        educationSupervisorName: "",
-                        educationSupervisorEmail: ""
-                      });
-                    } else {
-                      setFieldValue("covidDeclarationDto", null);
-                    }
+                  onChange={() => {
+                    setFieldValue("covidDeclarationDto", null, false);
                   }}
                 />
               </Panel>
@@ -243,21 +224,21 @@ const CovidDeclaration: FunctionComponent<SectionProps> = (
                       type="radios"
                       items={YES_NO_OPTIONS}
                       data-jest="haveChangesToPlacement"
-                      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                        setTimeout(() =>
-                          setFieldTouched("haveChangesToPlacement", true)
-                        );
+                      onChange={() => {
                         setFieldValue(
                           "covidDeclarationDto.changeCircumstances",
-                          ""
+                          null,
+                          false
                         );
                         setFieldValue(
                           "covidDeclarationDto.changeCircumstanceOther",
-                          ""
+                          null,
+                          false
                         );
                         setFieldValue(
                           "covidDeclarationDto.howPlacementAdjusted",
-                          ""
+                          null,
+                          false
                         );
                       }}
                     />
@@ -281,10 +262,10 @@ const CovidDeclaration: FunctionComponent<SectionProps> = (
                               "covidDeclarationDto.changeCircumstances",
                               e.target.value
                             );
-                            setFieldTouched("changeCircumstanceOther", true);
                             setFieldValue(
                               "covidDeclarationDto.changeCircumstanceOther",
-                              ""
+                              null,
+                              false
                             );
                           }}
                         />

--- a/src/components/forms/formr-part-b/Sections/CovidDeclaration.tsx
+++ b/src/components/forms/formr-part-b/Sections/CovidDeclaration.tsx
@@ -68,17 +68,29 @@ const CovidDeclaration: FunctionComponent<SectionProps> = (
                   type="radios"
                   items={YES_NO_OPTIONS}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    values.covidDeclarationDto = BooleanUtilities.ToBoolean(
-                      e.target.value
-                    )
-                      ? {
+                    if (!BooleanUtilities.ToBoolean(e.target.value)) {
+                      if (
+                        window.confirm(
+                          "Are you sure you want to clear the Covid form data?"
+                        )
+                      ) {
+                        setFieldValue("covidDeclarationDto", {
                           selfRateForCovid: "",
                           reasonOfSelfRate: "",
                           otherInformationForPanel: "",
                           discussWithSupervisorChecked: false,
-                          discussWithSomeoneChecked: false
-                        }
-                      : null;
+                          discussWithSomeoneChecked: false,
+                          haveChangesToPlacement: null,
+                          changeCircumstances: "",
+                          changeCircumstanceOther: "",
+                          howPlacementAdjusted: "",
+                          educationSupervisorName: "",
+                          educationSupervisorEmail: ""
+                        });
+                      } else {
+                        setFieldValue("haveCovidDeclarations", true);
+                      }
+                    }
                   }}
                 />
               </Panel>
@@ -208,48 +220,76 @@ const CovidDeclaration: FunctionComponent<SectionProps> = (
 
                     <MultiChoiceInputField
                       label="Changes were made to my placement due to my individual circumstances?"
-                      id="changesToPlacement"
-                      name="haveCovidDeclarachangesToPlacement"
+                      id="covidDeclarationDto.haveChangesToPlacement"
+                      name="covidDeclarationDto.haveChangesToPlacement"
                       type="radios"
                       items={YES_NO_OPTIONS}
+                      data-jest="haveChangesToPlacement"
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                        setFieldValue(
+                          "covidDeclarationDto.changeCircumstances",
+                          ""
+                        );
+                        setFieldValue(
+                          "covidDeclarationDto.changeCircumstanceOther",
+                          ""
+                        );
+                        setFieldValue(
+                          "covidDeclarationDto.howPlacementAdjusted",
+                          ""
+                        );
+                      }}
                     />
 
-                    <SelectInputField
-                      label="Circumstance of change"
-                      name="changeCircumstance"
-                      options={[
-                        {
-                          label: "Any Period of self-isolation",
-                          value: "Any Period of self-isolation"
-                        },
-                        {
-                          label:
-                            "Moving from front line services for those in high risk groups",
-                          value:
-                            "Moving from front line services for those in high risk groups"
-                        },
-                        {
-                          label: "Redeployed to support Covid-19 services",
-                          value: "Redeployed to support Covid-19 services"
-                        },
-                        {
-                          label:
-                            "Limited opportunities to curricula requirements",
-                          value:
-                            "Limited opportunities to curricula requirements"
-                        },
-                        { label: "Other", value: "Other" }
-                      ]}
-                    />
-                    <TextInputField
-                      label="If other, please explain"
-                      name="changeCircumstanceOther"
-                    />
-                    <TextInputField
-                      label="Please explain further how your placement was adjusted"
-                      name="howPlacementAdjusted"
-                      rows={5}
-                    />
+                    {BooleanUtilities.ToBoolean(
+                      values.covidDeclarationDto?.haveChangesToPlacement
+                    ) ? (
+                      <div
+                        data-jest="placementChanges"
+                        data-cy="placementChanges"
+                      >
+                        <SelectInputField
+                          label="Circumstance of change"
+                          name="covidDeclarationDto.changeCircumstances"
+                          data-jest="changeCircumstances"
+                          options={[
+                            {
+                              label: "Any Period of self-isolation",
+                              value: "Any Period of self-isolation"
+                            },
+                            {
+                              label:
+                                "Moving from front line services for those in high risk groups",
+                              value:
+                                "Moving from front line services for those in high risk groups"
+                            },
+                            {
+                              label: "Redeployed to support Covid-19 services",
+                              value: "Redeployed to support Covid-19 services"
+                            },
+                            {
+                              label:
+                                "Limited opportunities to curricula requirements",
+                              value:
+                                "Limited opportunities to curricula requirements"
+                            },
+                            { label: "Other", value: "Other" }
+                          ]}
+                        />
+
+                        <TextInputField
+                          label="If other, please explain"
+                          name="covidDeclarationDto.changeCircumstanceOther"
+                          data-jest="changeCircumstanceOther"
+                        />
+                        <TextInputField
+                          label="Please explain further how your placement was adjusted"
+                          name="covidDeclarationDto.howPlacementAdjusted"
+                          rows={5}
+                          data-jest="howPlacementAdjusted"
+                        />
+                      </div>
+                    ) : null}
                   </Panel>
 
                   <Panel label="Section 4: Educational Supervisor (ES) Report / Validation">
@@ -267,11 +307,13 @@ const CovidDeclaration: FunctionComponent<SectionProps> = (
                     </Label>
                     <TextInputField
                       label="Education Supervisor Name"
-                      name="educationSupervisorName"
+                      name="covidDeclarationDto.educationSupervisorName"
+                      data-jest="educationSupervisorName"
                     />
                     <TextInputField
                       label="Education Supervisor Email Address"
-                      name="educationSupervisorEmail"
+                      name="covidDeclarationDto.educationSupervisorEmail"
+                      data-jest="educationSupervisorEmail"
                     />
                   </Panel>
                 </div>

--- a/src/components/forms/formr-part-b/Sections/CovidDeclaration.tsx
+++ b/src/components/forms/formr-part-b/Sections/CovidDeclaration.tsx
@@ -5,6 +5,7 @@ import { Form, Formik } from "formik";
 import { SectionProps } from "./SectionProps";
 import FormRPartBPagination from "./FormRPartBPagination";
 import MultiChoiceInputField from "../../MultiChoiceInputField";
+import SelectInputField from "../../SelectInputField";
 import {
   YES_NO_OPTIONS,
   COVID_RESULT_DECLARATIONS,
@@ -59,46 +60,9 @@ const CovidDeclaration: FunctionComponent<SectionProps> = (
                 Doctors in Training ARCPs during COVID 19 Pandemic
               </Label>
 
-              <WarningCallout label="Important" data-cy="mainWarningCovid">
-                <div>
-                  <p>
-                    <b>IMPORTANT:</b> Please pre-populate this form with the
-                    information about your training since your last ARCP review,
-                    or this is the first scheduled ARCP in your programme, since
-                    the start of your current period of training.
-                  </p>
-                </div>
-                <div>
-                  Please comment on:
-                  <ul>
-                    <li>
-                      Your self-assessment of progress up to the point of COVID
-                      19
-                    </li>
-                    <li>
-                      How your training may have been impacted by COVID 19 you
-                      have not been able to acquire required
-                      competencies/capabilities through lack of appropriate
-                      learning opportunities or cancellation of required
-                      exams/courses
-                    </li>
-                    <li>Any other relevant information</li>
-                  </ul>
-                </div>
-                <div>
-                  <p>
-                    By signing this document, you are confirming that ALL
-                    details are correct and that you have made an honest
-                    declaration on accordance with the professional standards
-                    set out by the General Medica Council in Good Medical
-                    Practice.
-                  </p>
-                </div>
-              </WarningCallout>
-
               <Panel label="Covid declarations" data-cy="complimentsPanel">
                 <MultiChoiceInputField
-                  label="Does your placement has been affected by Covid-19?"
+                  label="Do you wish to complete the Covid 19 self declaration?"
                   id="haveCovidDeclarations"
                   name="haveCovidDeclarations"
                   type="radios"
@@ -121,6 +85,43 @@ const CovidDeclaration: FunctionComponent<SectionProps> = (
 
               {BooleanUtilities.ToBoolean(values.haveCovidDeclarations) ? (
                 <div data-jest="covidForm" data-cy="covidForm">
+                  <WarningCallout label="Important" data-cy="mainWarningCovid">
+                    <div>
+                      <p>
+                        <b>IMPORTANT:</b> Please pre-populate this form with the
+                        information about your training since your last ARCP
+                        review, or this is the first scheduled ARCP in your
+                        programme, since the start of your current period of
+                        training.
+                      </p>
+                    </div>
+                    <div>
+                      Please comment on:
+                      <ul>
+                        <li>
+                          Your self-assessment of progress up to the point of
+                          COVID 19
+                        </li>
+                        <li>
+                          How your training may have been impacted by COVID 19
+                          you have not been able to acquire required
+                          competencies/capabilities through lack of appropriate
+                          learning opportunities or cancellation of required
+                          exams/courses
+                        </li>
+                        <li>Any other relevant information</li>
+                      </ul>
+                    </div>
+                    <div>
+                      <p>
+                        By signing this document, you are confirming that ALL
+                        details are correct and that you have made an honest
+                        declaration on accordance with the professional
+                        standards set out by the General Medica Council in Good
+                        Medical Practice.
+                      </p>
+                    </div>
+                  </WarningCallout>
                   <Panel label="Section 1: Trainee self-assessment of progress">
                     <Label>
                       <b>
@@ -191,6 +192,86 @@ const CovidDeclaration: FunctionComponent<SectionProps> = (
                           value: true
                         }
                       ]}
+                    />
+                  </Panel>
+
+                  <Panel label="Section 3: Trainee placement changes">
+                    <Label>
+                      <p>
+                        Please indicate any changes to your placement caused by
+                        your individual circumstances e.g. moving from frontline
+                        services for those in high-risk groups. Include as much
+                        information as possible including details of any periods
+                        of self-isolation with dates
+                      </p>
+                    </Label>
+
+                    <MultiChoiceInputField
+                      label="Changes were made to my placement due to my individual circumstances?"
+                      id="changesToPlacement"
+                      name="haveCovidDeclarachangesToPlacement"
+                      type="radios"
+                      items={YES_NO_OPTIONS}
+                    />
+
+                    <SelectInputField
+                      label="Circumstance of change"
+                      name="changeCircumstance"
+                      options={[
+                        {
+                          label: "Any Period of self-isolation",
+                          value: "Any Period of self-isolation"
+                        },
+                        {
+                          label:
+                            "Moving from front line services for those in high risk groups",
+                          value:
+                            "Moving from front line services for those in high risk groups"
+                        },
+                        {
+                          label: "Redeployed to support Covid-19 services",
+                          value: "Redeployed to support Covid-19 services"
+                        },
+                        {
+                          label:
+                            "Limited opportunities to curricula requirements",
+                          value:
+                            "Limited opportunities to curricula requirements"
+                        },
+                        { label: "Other", value: "Other" }
+                      ]}
+                    />
+                    <TextInputField
+                      label="If other, please explain"
+                      name="changeCircumstanceOther"
+                    />
+                    <TextInputField
+                      label="Please explain further how your placement was adjusted"
+                      name="howPlacementAdjusted"
+                      rows={5}
+                    />
+                  </Panel>
+
+                  <Panel label="Section 4: Educational Supervisor (ES) Report / Validation">
+                    <Label>
+                      <p>
+                        Please provide details of your Educational Supervisor in
+                        this section. A copy of this form will need to be sent
+                        to your ES when you submit this form. This will give
+                        your ES the opportunity to review the information
+                        provided in the self-assessment declaration, comment and
+                        confirm / validate them and make a recommendation for
+                        the ARCP during COVID 19. This will be completed by the
+                        ES in your ePortfolio.
+                      </p>
+                    </Label>
+                    <TextInputField
+                      label="Education Supervisor Name"
+                      name="educationSupervisorName"
+                    />
+                    <TextInputField
+                      label="Education Supervisor Email Address"
+                      name="educationSupervisorEmail"
                     />
                   </Panel>
                 </div>

--- a/src/components/forms/formr-part-b/Sections/CovidDeclaration.tsx
+++ b/src/components/forms/formr-part-b/Sections/CovidDeclaration.tsx
@@ -262,29 +262,6 @@ const CovidDeclaration: FunctionComponent<SectionProps> = (
                           label="Circumstance of change"
                           name="covidDeclarationDto.changeCircumstances"
                           data-jest="changeCircumstances"
-                          options={[
-                            {
-                              label: "Any Period of self-isolation",
-                              value: "Any Period of self-isolation"
-                            },
-                            {
-                              label:
-                                "Moving from front line services for those in high risk groups",
-                              value:
-                                "Moving from front line services for those in high risk groups"
-                            },
-                            {
-                              label: "Redeployed to support Covid-19 services",
-                              value: "Redeployed to support Covid-19 services"
-                            },
-                            {
-                              label:
-                                "Limited opportunities to curricula requirements",
-                              value:
-                                "Limited opportunities to curricula requirements"
-                            },
-                            { label: "Other", value: "Other" }
-                          ]}
                         />
 
                         <TextInputField

--- a/src/components/forms/formr-part-b/Sections/CovidDeclaration.tsx
+++ b/src/components/forms/formr-part-b/Sections/CovidDeclaration.tsx
@@ -33,13 +33,15 @@ const CovidDeclaration: FunctionComponent<SectionProps> = (
   return (
     formData && (
       <Formik
+        validateOnChange={false}
+        validateOnBlur={true}
         initialValues={formData}
         validationSchema={CovidSectionValidationSchema}
         onSubmit={values => {
           nextSection(values);
         }}
       >
-        {({ values, setFieldValue, handleSubmit }) => (
+        {({ values, setFieldValue, setFieldTouched, handleSubmit }) => (
           <Form>
             <ScrollTo />
             <Fieldset
@@ -68,25 +70,30 @@ const CovidDeclaration: FunctionComponent<SectionProps> = (
                   type="radios"
                   items={YES_NO_OPTIONS}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    if (!BooleanUtilities.ToBoolean(e.target.value)) {
+                    setTimeout(() =>
+                      setFieldTouched("haveCovidDeclarations", true)
+                    );
+                    if (BooleanUtilities.ToBoolean(e.target.value)) {
+                      setFieldValue("covidDeclarationDto", {
+                        selfRateForCovid: "",
+                        reasonOfSelfRate: "",
+                        otherInformationForPanel: "",
+                        discussWithSupervisorChecked: false,
+                        discussWithSomeoneChecked: false,
+                        haveChangesToPlacement: "",
+                        changeCircumstances: "",
+                        changeCircumstanceOther: "",
+                        howPlacementAdjusted: "",
+                        educationSupervisorName: "",
+                        educationSupervisorEmail: ""
+                      });
+                    } else {
                       if (
                         window.confirm(
                           "Are you sure you want to clear the Covid form data?"
                         )
                       ) {
-                        setFieldValue("covidDeclarationDto", {
-                          selfRateForCovid: "",
-                          reasonOfSelfRate: "",
-                          otherInformationForPanel: "",
-                          discussWithSupervisorChecked: false,
-                          discussWithSomeoneChecked: false,
-                          haveChangesToPlacement: null,
-                          changeCircumstances: "",
-                          changeCircumstanceOther: "",
-                          howPlacementAdjusted: "",
-                          educationSupervisorName: "",
-                          educationSupervisorEmail: ""
-                        });
+                        setFieldValue("covidDeclarationDto", null);
                       } else {
                         setFieldValue("haveCovidDeclarations", true);
                       }
@@ -226,6 +233,9 @@ const CovidDeclaration: FunctionComponent<SectionProps> = (
                       items={YES_NO_OPTIONS}
                       data-jest="haveChangesToPlacement"
                       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                        setTimeout(() =>
+                          setFieldTouched("haveChangesToPlacement", true)
+                        );
                         setFieldValue(
                           "covidDeclarationDto.changeCircumstances",
                           ""

--- a/src/components/forms/formr-part-b/Sections/CovidDeclaration.tsx
+++ b/src/components/forms/formr-part-b/Sections/CovidDeclaration.tsx
@@ -45,6 +45,7 @@ const CovidDeclaration: FunctionComponent<SectionProps> = (
           };
         }
       );
+      console.log(responseChangeCircumstances);
       setChangeCircumstances(responseChangeCircumstances);
     };
     fetchData();
@@ -53,8 +54,6 @@ const CovidDeclaration: FunctionComponent<SectionProps> = (
   return (
     formData && (
       <Formik
-        validateOnChange={false}
-        validateOnBlur={true}
         initialValues={formData}
         validationSchema={CovidSectionValidationSchema}
         onSubmit={values => {
@@ -108,15 +107,7 @@ const CovidDeclaration: FunctionComponent<SectionProps> = (
                         educationSupervisorEmail: ""
                       });
                     } else {
-                      if (
-                        window.confirm(
-                          "Are you sure you want to clear the Covid form data?"
-                        )
-                      ) {
-                        setFieldValue("covidDeclarationDto", null);
-                      } else {
-                        setFieldValue("haveCovidDeclarations", true);
-                      }
+                      setFieldValue("covidDeclarationDto", null);
                     }
                   }}
                 />

--- a/src/components/forms/formr-part-b/Sections/CovidDeclaration.tsx
+++ b/src/components/forms/formr-part-b/Sections/CovidDeclaration.tsx
@@ -274,6 +274,19 @@ const CovidDeclaration: FunctionComponent<SectionProps> = (
                           name="covidDeclarationDto.changeCircumstances"
                           data-jest="changeCircumstances"
                           options={changeCircumstances}
+                          onChange={(
+                            e: React.ChangeEvent<HTMLInputElement>
+                          ) => {
+                            setFieldValue(
+                              "covidDeclarationDto.changeCircumstances",
+                              e.target.value
+                            );
+                            setFieldTouched("changeCircumstanceOther", true);
+                            setFieldValue(
+                              "covidDeclarationDto.changeCircumstanceOther",
+                              ""
+                            );
+                          }}
                         />
                         {values.covidDeclarationDto?.changeCircumstances ===
                         "Other" ? (

--- a/src/components/forms/formr-part-b/Sections/CovidDeclaration.tsx
+++ b/src/components/forms/formr-part-b/Sections/CovidDeclaration.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from "react";
+import React, { FunctionComponent, useEffect, useState } from "react";
 import ScrollTo from "../../ScrollTo";
 import { Fieldset, Panel, Label, WarningCallout } from "nhsuk-react-components";
 import { Form, Formik } from "formik";
@@ -16,6 +16,7 @@ import { CovidSectionValidationSchema } from "../ValidationSchema";
 import { BooleanUtilities } from "../../../../utilities/BooleanUtilities";
 import TextInputField from "../../TextInputField";
 import { KeyValue } from "../../../../models/KeyValue";
+import { TraineeReferenceService } from "../../../../services/TraineeReferenceService";
 
 const CovidDeclaration: FunctionComponent<SectionProps> = (
   props: SectionProps
@@ -29,6 +30,25 @@ const CovidDeclaration: FunctionComponent<SectionProps> = (
     nextSectionLabel,
     section
   } = props;
+
+  const [changeCircumstances, setChangeCircumstances] = useState([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const traineeReferenceService = new TraineeReferenceService();
+      const response = await traineeReferenceService.getCovidChangeCircs();
+      const responseChangeCircumstances = response.data.map(
+        (d: { label: any }) => {
+          return {
+            label: d.label,
+            value: d.label
+          };
+        }
+      );
+      setChangeCircumstances(responseChangeCircumstances);
+    };
+    fetchData();
+  }, []);
 
   return (
     formData && (
@@ -262,6 +282,7 @@ const CovidDeclaration: FunctionComponent<SectionProps> = (
                           label="Circumstance of change"
                           name="covidDeclarationDto.changeCircumstances"
                           data-jest="changeCircumstances"
+                          options={changeCircumstances}
                         />
 
                         <TextInputField

--- a/src/components/forms/formr-part-b/Sections/CovidDeclaration.tsx
+++ b/src/components/forms/formr-part-b/Sections/CovidDeclaration.tsx
@@ -45,7 +45,7 @@ const CovidDeclaration: FunctionComponent<SectionProps> = (
           };
         }
       );
-      console.log(responseChangeCircumstances);
+
       setChangeCircumstances(responseChangeCircumstances);
     };
     fetchData();
@@ -275,12 +275,15 @@ const CovidDeclaration: FunctionComponent<SectionProps> = (
                           data-jest="changeCircumstances"
                           options={changeCircumstances}
                         />
+                        {values.covidDeclarationDto?.changeCircumstances ===
+                        "Other" ? (
+                          <TextInputField
+                            label="If other, please explain"
+                            name="covidDeclarationDto.changeCircumstanceOther"
+                            data-jest="changeCircumstanceOther"
+                          />
+                        ) : null}
 
-                        <TextInputField
-                          label="If other, please explain"
-                          name="covidDeclarationDto.changeCircumstanceOther"
-                          data-jest="changeCircumstanceOther"
-                        />
                         <TextInputField
                           label="Please explain further how your placement was adjusted"
                           name="covidDeclarationDto.howPlacementAdjusted"

--- a/src/components/forms/formr-part-b/Sections/FormRPartBPagination.tsx
+++ b/src/components/forms/formr-part-b/Sections/FormRPartBPagination.tsx
@@ -29,6 +29,7 @@ const FormRPartBPagination: React.FC<Props> = (props: Props) => {
           previous
           onClick={() => props.previousSection(values, section && section - 1)}
           data-cy="LinkToPreviousSection"
+          data-jest={section ? "LinkToPreviousSection" + (section - 1) : ""}
         >
           {prevSectionLabel.split("\n").map((item, index) => (
             <div key={index}>{item}</div>
@@ -46,6 +47,7 @@ const FormRPartBPagination: React.FC<Props> = (props: Props) => {
         next
         onClick={() => props.handleSubmit()}
         data-cy="LinkToNextSection"
+        data-jest={section ? "LinkToNextSection" + (section + 1) : ""}
       >
         {nextSectionLabel
           ? nextSectionLabel

--- a/src/components/forms/formr-part-b/Sections/Section3.tsx
+++ b/src/components/forms/formr-part-b/Sections/Section3.tsx
@@ -13,6 +13,7 @@ import { Form, Formik } from "formik";
 import { Section3ValidationSchema } from "../ValidationSchema";
 import { SectionProps } from "./SectionProps";
 import FormRPartBPagination from "./FormRPartBPagination";
+import { YES_NO_OPTIONS } from "../../../../utilities/Constants";
 
 const Section3: FunctionComponent<SectionProps> = (props: SectionProps) => {
   const {
@@ -102,10 +103,7 @@ const Section3: FunctionComponent<SectionProps> = (props: SectionProps) => {
                   id="isWarned"
                   name="isWarned"
                   type="radios"
-                  items={[
-                    { label: "Yes", value: "true" },
-                    { label: "No", value: "false" }
-                  ]}
+                  items={YES_NO_OPTIONS}
                 />
 
                 {values.isWarned && values.isWarned.toString() === "true" ? (

--- a/src/components/forms/formr-part-b/Sections/Section3.tsx
+++ b/src/components/forms/formr-part-b/Sections/Section3.tsx
@@ -34,7 +34,7 @@ const Section3: FunctionComponent<SectionProps> = (props: SectionProps) => {
           nextSection(values);
         }}
       >
-        {({ values, errors, handleSubmit }) => (
+        {({ values, errors, handleSubmit, setFieldValue }) => (
           <Form>
             <ScrollTo />
             <Fieldset
@@ -104,6 +104,9 @@ const Section3: FunctionComponent<SectionProps> = (props: SectionProps) => {
                   name="isWarned"
                   type="radios"
                   items={YES_NO_OPTIONS}
+                  onChange={() => {
+                    setFieldValue("isComplying", null, false);
+                  }}
                 />
 
                 {values.isWarned && values.isWarned.toString() === "true" ? (

--- a/src/components/forms/formr-part-b/Sections/Section4.tsx
+++ b/src/components/forms/formr-part-b/Sections/Section4.tsx
@@ -47,7 +47,7 @@ const Section4: FunctionComponent<SectionProps> = (props: SectionProps) => {
           nextSection(values);
         }}
       >
-        {({ values, errors, handleSubmit }) => (
+        {({ values, errors, handleSubmit, setFieldValue }) => (
           <Form>
             <ScrollTo />
             <Fieldset
@@ -92,6 +92,7 @@ const Section4: FunctionComponent<SectionProps> = (props: SectionProps) => {
                       values.previousDeclarations,
                       newDeclaration
                     );
+                    setFieldValue("previousDeclarationSummary", null, false);
                   }}
                   type="radios"
                   items={YES_NO_OPTIONS}

--- a/src/components/forms/formr-part-b/Sections/Section5.tsx
+++ b/src/components/forms/formr-part-b/Sections/Section5.tsx
@@ -46,7 +46,7 @@ const Section5: FunctionComponent<SectionProps> = (props: SectionProps) => {
           nextSection(values);
         }}
       >
-        {({ values, errors, handleSubmit }) => (
+        {({ values, errors, handleSubmit, setFieldValue }) => (
           <Form>
             <ScrollTo />
             <Fieldset
@@ -111,6 +111,7 @@ const Section5: FunctionComponent<SectionProps> = (props: SectionProps) => {
                       values.currentDeclarations,
                       newDeclaration
                     );
+                    setFieldValue("currentDeclarationSummary", null, false);
                   }}
                   items={YES_NO_OPTIONS}
                   footer="If you wish to make any such declarations in relation to your previous Form R Part B then please do this in Section 4"

--- a/src/components/forms/formr-part-b/ValidationSchema.ts
+++ b/src/components/forms/formr-part-b/ValidationSchema.ts
@@ -181,6 +181,7 @@ export const CovidSectionValidationSchema = yup.object({
         ),
         educationSupervisorEmail: yup
           .string()
+          .nullable()
           .email("Email is invalid")
           .max(255, "Email must be shorter than 255 characters")
           .required("Email is required"),
@@ -189,16 +190,26 @@ export const CovidSectionValidationSchema = yup.object({
           .nullable()
           .required("You must select yes or no"),
         changeCircumstances: StringValidationSchema("Circumstance of change"),
-        changeCircumstanceOther: yup.string().when("changeCircumstances", {
-          is: changeCircumstance => changeCircumstance === "Other",
-          then: yup.string().required("Other circumstance is required`")
-        }),
-        howPlacementAdjusted: yup.string().when("haveChangesToPlacement", {
-          is: true,
-          then: yup
-            .string()
-            .required("How your placement was adjusted is required")
-        })
+        changeCircumstanceOther: yup
+          .string()
+          .nullable()
+          .when("changeCircumstances", {
+            is: changeCircumstance => changeCircumstance === "Other",
+            then: yup
+              .string()
+              .nullable()
+              .required("Other circumstance is required")
+          }),
+        howPlacementAdjusted: yup
+          .string()
+          .nullable()
+          .when("haveChangesToPlacement", {
+            is: true,
+            then: yup
+              .string()
+              .nullable()
+              .required("How your placement was adjusted is required")
+          })
       })
     })
 });

--- a/src/components/forms/formr-part-b/ValidationSchema.ts
+++ b/src/components/forms/formr-part-b/ValidationSchema.ts
@@ -174,7 +174,26 @@ export const CovidSectionValidationSchema = yup.object({
         otherInformationForPanel: StringValidationSchema(
           "Other Information for Panel",
           2000
-        )
+        ),
+        educationSupervisorName: StringValidationSchema(
+          "Education Supervisor Name",
+          300
+        ),
+        educationSupervisorEmail: yup
+          .string()
+          .email("Email is invalid")
+          .max(255, "Email must be shorter than 255 characters")
+          .required("Email is required"),
+        haveChangesToPlacement: yup
+          .boolean()
+          .nullable()
+          .required("You must select yes or no"),
+        howPlacementAdjusted: yup.string().when("haveChangesToPlacement", {
+          is: true,
+          then: yup
+            .string()
+            .required("How your placement was adjusted is required`")
+        })
       })
     })
 });

--- a/src/components/forms/formr-part-b/ValidationSchema.ts
+++ b/src/components/forms/formr-part-b/ValidationSchema.ts
@@ -188,11 +188,16 @@ export const CovidSectionValidationSchema = yup.object({
           .boolean()
           .nullable()
           .required("You must select yes or no"),
+        changeCircumstances: StringValidationSchema("Circumstance of change"),
+        changeCircumstanceOther: yup.string().when("changeCircumstances", {
+          is: changeCircumstance => changeCircumstance === "Other",
+          then: yup.string().required("Other circumstance is required`")
+        }),
         howPlacementAdjusted: yup.string().when("haveChangesToPlacement", {
           is: true,
           then: yup
             .string()
-            .required("How your placement was adjusted is required`")
+            .required("How your placement was adjusted is required")
         })
       })
     })

--- a/src/components/forms/formr-part-b/View.tsx
+++ b/src/components/forms/formr-part-b/View.tsx
@@ -652,6 +652,19 @@ class View extends React.PureComponent<ViewProps> {
                         </SummaryList.Value>
                       </SummaryList.Row>
 
+                      {formData.covidDeclarationDto?.changeCircumstances ===
+                      "Other" ? (
+                        <SummaryList.Row>
+                          <SummaryList.Key>Other circumstance</SummaryList.Key>
+                          <SummaryList.Value>
+                            {
+                              formData.covidDeclarationDto
+                                ?.changeCircumstanceOther
+                            }
+                          </SummaryList.Value>
+                        </SummaryList.Row>
+                      ) : null}
+
                       <SummaryList.Row>
                         <SummaryList.Key>
                           Please explain further how your placement was adjusted

--- a/src/components/forms/formr-part-b/View.tsx
+++ b/src/components/forms/formr-part-b/View.tsx
@@ -543,7 +543,7 @@ class View extends React.PureComponent<ViewProps> {
             </SummaryList>
           </Panel>
 
-          {enableCovidDeclaration || formData.haveCovidDeclarations ? (
+          {enableCovidDeclaration || formData.haveCovidDeclarations || true ? (
             <>
               <div className="nhsuk-grid-row">
                 <div
@@ -624,8 +624,67 @@ class View extends React.PureComponent<ViewProps> {
                   </SummaryList.Row>
                 </SummaryList>
               </Panel>
+
+              <Panel label="Section 3: Trainee placement changes">
+                <SummaryList>
+                  <SummaryList.Row>
+                    <SummaryList.Key>
+                      Changes were made to my placement due to my individual
+                      circumstances
+                    </SummaryList.Key>
+                    <SummaryList.Value>
+                      {BooleanUtilities.ToYesNo(
+                        formData.covidDeclarationDto?.haveChangesToPlacement
+                      )}
+                    </SummaryList.Value>
+                  </SummaryList.Row>
+
+                  {BooleanUtilities.ToBoolean(
+                    formData.covidDeclarationDto?.haveChangesToPlacement
+                  ) ? (
+                    <>
+                      <SummaryList.Row>
+                        <SummaryList.Key>
+                          Circumstance of change
+                        </SummaryList.Key>
+                        <SummaryList.Value>
+                          {formData.covidDeclarationDto?.changeCircumstances}
+                        </SummaryList.Value>
+                      </SummaryList.Row>
+
+                      <SummaryList.Row>
+                        <SummaryList.Key>
+                          Please explain further how your placement was adjusted
+                        </SummaryList.Key>
+                        <SummaryList.Value>
+                          {formData.covidDeclarationDto?.howPlacementAdjusted}
+                        </SummaryList.Value>
+                      </SummaryList.Row>
+                    </>
+                  ) : null}
+                </SummaryList>
+              </Panel>
             </>
           ) : null}
+
+          <Panel label="Section 4: Educational Supervisor (ES) Report / Validation">
+            <SummaryList>
+              <SummaryList.Row>
+                <SummaryList.Key>Education Supervisor Name</SummaryList.Key>
+                <SummaryList.Value>
+                  {formData.covidDeclarationDto?.educationSupervisorName}
+                </SummaryList.Value>
+              </SummaryList.Row>
+              <SummaryList.Row>
+                <SummaryList.Key>
+                  Education Supervisor Email Address
+                </SummaryList.Key>
+                <SummaryList.Value>
+                  {formData.covidDeclarationDto?.educationSupervisorEmail}
+                </SummaryList.Value>
+              </SummaryList.Row>
+            </SummaryList>
+          </Panel>
 
           <div className="nhsuk-grid-row">
             <div

--- a/src/components/forms/formr-part-b/View.tsx
+++ b/src/components/forms/formr-part-b/View.tsx
@@ -543,7 +543,7 @@ class View extends React.PureComponent<ViewProps> {
             </SummaryList>
           </Panel>
 
-          {enableCovidDeclaration || formData.haveCovidDeclarations || true ? (
+          {enableCovidDeclaration ? (
             <>
               <div className="nhsuk-grid-row">
                 <div
@@ -599,105 +599,127 @@ class View extends React.PureComponent<ViewProps> {
                 ) : null}
               </Panel>
 
-              <Panel label="Section 2: Trainee Check-In">
-                <SummaryList>
-                  <SummaryList.Row>
-                    <SummaryList.Key>
-                      {NEED_DISCUSSION_WITH_SUPERVISOR}
-                    </SummaryList.Key>
-                    <SummaryList.Value>
-                      {BooleanUtilities.ToYesNo(
-                        formData.covidDeclarationDto
-                          ?.discussWithSupervisorChecked
-                      )}
-                    </SummaryList.Value>
-                  </SummaryList.Row>
-                  <SummaryList.Row>
-                    <SummaryList.Key>
-                      {NEED_DISCUSSION_WITH_SOMEONE}
-                    </SummaryList.Key>
-                    <SummaryList.Value>
-                      {BooleanUtilities.ToYesNo(
-                        formData.covidDeclarationDto?.discussWithSomeoneChecked
-                      )}
-                    </SummaryList.Value>
-                  </SummaryList.Row>
-                </SummaryList>
-              </Panel>
+              {BooleanUtilities.ToBoolean(formData.haveCovidDeclarations) ? (
+                <>
+                  <Panel label="Section 2: Trainee Check-In">
+                    <SummaryList>
+                      <SummaryList.Row>
+                        <SummaryList.Key>
+                          {NEED_DISCUSSION_WITH_SUPERVISOR}
+                        </SummaryList.Key>
+                        <SummaryList.Value>
+                          {BooleanUtilities.ToYesNo(
+                            formData.covidDeclarationDto
+                              ?.discussWithSupervisorChecked
+                          )}
+                        </SummaryList.Value>
+                      </SummaryList.Row>
+                      <SummaryList.Row>
+                        <SummaryList.Key>
+                          {NEED_DISCUSSION_WITH_SOMEONE}
+                        </SummaryList.Key>
+                        <SummaryList.Value>
+                          {BooleanUtilities.ToYesNo(
+                            formData.covidDeclarationDto
+                              ?.discussWithSomeoneChecked
+                          )}
+                        </SummaryList.Value>
+                      </SummaryList.Row>
+                    </SummaryList>
+                  </Panel>
 
-              <Panel label="Section 3: Trainee placement changes">
-                <SummaryList>
-                  <SummaryList.Row>
-                    <SummaryList.Key>
-                      Changes were made to my placement due to my individual
-                      circumstances
-                    </SummaryList.Key>
-                    <SummaryList.Value>
-                      {BooleanUtilities.ToYesNo(
+                  <Panel label="Section 3: Trainee placement changes">
+                    <SummaryList>
+                      <SummaryList.Row>
+                        <SummaryList.Key>
+                          Changes were made to my placement due to my individual
+                          circumstances
+                        </SummaryList.Key>
+                        <SummaryList.Value>
+                          {BooleanUtilities.ToYesNo(
+                            formData.covidDeclarationDto?.haveChangesToPlacement
+                          )}
+                        </SummaryList.Value>
+                      </SummaryList.Row>
+
+                      {BooleanUtilities.ToBoolean(
                         formData.covidDeclarationDto?.haveChangesToPlacement
-                      )}
-                    </SummaryList.Value>
-                  </SummaryList.Row>
+                      ) ? (
+                        <>
+                          <SummaryList.Row>
+                            <SummaryList.Key>
+                              Circumstance of change
+                            </SummaryList.Key>
+                            <SummaryList.Value>
+                              {
+                                formData.covidDeclarationDto
+                                  ?.changeCircumstances
+                              }
+                            </SummaryList.Value>
+                          </SummaryList.Row>
 
-                  {BooleanUtilities.ToBoolean(
-                    formData.covidDeclarationDto?.haveChangesToPlacement
-                  ) ? (
-                    <>
-                      <SummaryList.Row>
-                        <SummaryList.Key>
-                          Circumstance of change
-                        </SummaryList.Key>
-                        <SummaryList.Value>
-                          {formData.covidDeclarationDto?.changeCircumstances}
-                        </SummaryList.Value>
-                      </SummaryList.Row>
+                          {formData.covidDeclarationDto?.changeCircumstances ===
+                          "Other" ? (
+                            <SummaryList.Row>
+                              <SummaryList.Key>
+                                Other circumstance
+                              </SummaryList.Key>
+                              <SummaryList.Value>
+                                {
+                                  formData.covidDeclarationDto
+                                    ?.changeCircumstanceOther
+                                }
+                              </SummaryList.Value>
+                            </SummaryList.Row>
+                          ) : null}
 
-                      {formData.covidDeclarationDto?.changeCircumstances ===
-                      "Other" ? (
-                        <SummaryList.Row>
-                          <SummaryList.Key>Other circumstance</SummaryList.Key>
-                          <SummaryList.Value>
-                            {
-                              formData.covidDeclarationDto
-                                ?.changeCircumstanceOther
-                            }
-                          </SummaryList.Value>
-                        </SummaryList.Row>
+                          <SummaryList.Row>
+                            <SummaryList.Key>
+                              Please explain further how your placement was
+                              adjusted
+                            </SummaryList.Key>
+                            <SummaryList.Value>
+                              {
+                                formData.covidDeclarationDto
+                                  ?.howPlacementAdjusted
+                              }
+                            </SummaryList.Value>
+                          </SummaryList.Row>
+                        </>
                       ) : null}
+                    </SummaryList>
+                  </Panel>
 
+                  <Panel label="Section 4: Educational Supervisor (ES) Report / Validation">
+                    <SummaryList>
                       <SummaryList.Row>
                         <SummaryList.Key>
-                          Please explain further how your placement was adjusted
+                          Education Supervisor Name
                         </SummaryList.Key>
                         <SummaryList.Value>
-                          {formData.covidDeclarationDto?.howPlacementAdjusted}
+                          {
+                            formData.covidDeclarationDto
+                              ?.educationSupervisorName
+                          }
                         </SummaryList.Value>
                       </SummaryList.Row>
-                    </>
-                  ) : null}
-                </SummaryList>
-              </Panel>
+                      <SummaryList.Row>
+                        <SummaryList.Key>
+                          Education Supervisor Email Address
+                        </SummaryList.Key>
+                        <SummaryList.Value>
+                          {
+                            formData.covidDeclarationDto
+                              ?.educationSupervisorEmail
+                          }
+                        </SummaryList.Value>
+                      </SummaryList.Row>
+                    </SummaryList>
+                  </Panel>
+                </>
+              ) : null}
             </>
           ) : null}
-
-          <Panel label="Section 4: Educational Supervisor (ES) Report / Validation">
-            <SummaryList>
-              <SummaryList.Row>
-                <SummaryList.Key>Education Supervisor Name</SummaryList.Key>
-                <SummaryList.Value>
-                  {formData.covidDeclarationDto?.educationSupervisorName}
-                </SummaryList.Value>
-              </SummaryList.Row>
-              <SummaryList.Row>
-                <SummaryList.Key>
-                  Education Supervisor Email Address
-                </SummaryList.Key>
-                <SummaryList.Value>
-                  {formData.covidDeclarationDto?.educationSupervisorEmail}
-                </SummaryList.Value>
-              </SummaryList.Row>
-            </SummaryList>
-          </Panel>
 
           <div className="nhsuk-grid-row">
             <div

--- a/src/components/forms/formr-part-b/View.tsx
+++ b/src/components/forms/formr-part-b/View.tsx
@@ -543,8 +543,7 @@ class View extends React.PureComponent<ViewProps> {
             </SummaryList>
           </Panel>
 
-          {enableCovidDeclaration ||
-          BooleanUtilities.ToYesNo(formData.haveCovidDeclarations) ? (
+          {enableCovidDeclaration || formData.haveCovidDeclarations ? (
             <>
               <div className="nhsuk-grid-row">
                 <div

--- a/src/components/forms/formr-part-b/__test__/Confirm.test.tsx
+++ b/src/components/forms/formr-part-b/__test__/Confirm.test.tsx
@@ -9,7 +9,7 @@ import { submittedFormRPartBs } from "../../../../mock-data/submitted-formr-part
 import { act } from "react-test-renderer";
 import { BrowserRouter, Redirect } from "react-router-dom";
 
-const showCovidDeclarationFeature: boolean = true;
+const showCovidDeclarationFeature: boolean = false;
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 let btnLength = showCovidDeclarationFeature ? 10 : 9;
@@ -42,13 +42,13 @@ describe("Confirm", () => {
     mountComponent(submittedFormRPartBs[0], null);
   });
 
-  it("should redirect to create page when no data availabe", () => {
+  it("should redirect to create page when no data available", () => {
     const wrapper = mountComponent(null, null);
 
     expect(wrapper.find(Redirect)).toHaveLength(1);
   });
 
-  it("renders the edit and confirm buttons when form data is avaialbe", () => {
+  it("renders the edit and confirm buttons when form data is available", () => {
     const wrapper = mountComponent(submittedFormRPartBs[0], null);
 
     expect(wrapper.find("button")).toHaveLength(btnLength);

--- a/src/components/forms/formr-part-b/__test__/CovidDeclaration.test.tsx
+++ b/src/components/forms/formr-part-b/__test__/CovidDeclaration.test.tsx
@@ -62,14 +62,13 @@ describe("Form-R Part-B CovidDeclaration", () => {
   });
 
   it("should render the affected by Covid form when 'yes' is selected and remove when 'no' selected", () => {
-    //props.formData.haveCovidDeclarations = true;
     const component = mount(<CovidDeclaration {...props} />);
     const wrapper = component.find("[data-jest='haveCovidDeclarations'] input");
-    wrapper.first().simulate("click");
+    wrapper.first().simulate("change", { target: { value: true } });
     setTimeout(() => {
       expect(component.find(["data-jest='covidForm"]).length).toBe(1);
     }, 300);
-    wrapper.last().simulate("click");
+    wrapper.last().simulate("change", { target: { value: true } });
     setTimeout(() => {
       expect(component.find(["data-jest='covidForm"]).length).toBe(0);
     }, 300);
@@ -81,7 +80,7 @@ describe("Form-R Part-B CovidDeclaration", () => {
       const wrapper = component.find(
         "[data-jest='haveCovidDeclarations'] input"
       );
-      wrapper.first().simulate("click");
+      wrapper.first().simulate("change", { target: { value: true } });
       setTimeout(() => {
         expect(
           component.find(
@@ -122,14 +121,14 @@ describe("Form-R Part-B CovidDeclaration", () => {
       const wrapper = component.find(
         "[data-jest='haveCovidDeclarations'] input"
       );
-      wrapper.first().simulate("click");
+      wrapper.first().simulate("change", { target: { value: true } });
       setTimeout(() => {
         component
           .find(
             "[data-jest='covidDeclarationDto.selfRateForCovid] input[type='radio']"
           )
           .at(1)
-          .simulate("click");
+          .simulate("change", { target: { value: true } });
         expect(
           component.find(
             "[data-jest='covidDeclarationDto.selfRateForCovid] .nhsuk-radios__conditional"
@@ -143,7 +142,7 @@ describe("Form-R Part-B CovidDeclaration", () => {
       const wrapper = component.find(
         "[data-jest='haveCovidDeclarations'] input"
       );
-      wrapper.first().simulate("click");
+      wrapper.first().simulate("change", { target: { value: true } });
       setTimeout(() => {
         expect(
           component.find(
@@ -153,6 +152,106 @@ describe("Form-R Part-B CovidDeclaration", () => {
       }, 300);
     });
   });
+
+  it("should render two radio buttons valued true and false flagging if changes have been made to placement both unchecked", () => {
+    const component = mount(<CovidDeclaration {...props} />);
+    const wrapper = component.find("[data-jest='haveCovidDeclarations'] input");
+    wrapper.first().simulate("change", { target: { value: true } });
+    setTimeout(() => {
+      expect(
+        component.find("[data-jest='haveChangesToPlacement'] input").length
+      ).toBe(2);
+      expect(
+        component
+          .find("[data-jest='haveChangesToPlacement'] input")
+          .first()
+          .prop("checked")
+      ).toBe(false);
+      expect(
+        component
+          .find("[data-jest='haveChangesToPlacement'] input")
+          .first()
+          .prop("value")
+      ).toBe("true");
+      expect(
+        component
+          .find("[data-jest='haveChangesToPlacement'] input")
+          .last()
+          .prop("checked")
+      ).toBe(false);
+      expect(
+        component
+          .find("[data-jest='haveChangesToPlacement'] input")
+          .last()
+          .prop("value")
+      ).toBe("false");
+    }, 300);
+  });
+
+  it("should conditionally render fields for entering placement change details", () => {
+    const component = mount(<CovidDeclaration {...props} />);
+    const wrapper = component.find("[data-jest='haveCovidDeclarations'] input");
+    wrapper.first().simulate("change", { target: { value: true } });
+    setTimeout(() => {
+      component
+        .find("[data-jest='haveChangesToPlacement'] input")
+        .first()
+        .simulate("change", { target: { value: true } });
+      expect(component.find("[data-jest='placementChanges']").length).toBe(1);
+    });
+  });
+
+  it("should clear typed values when toggling flag", () => {
+    const component = mount(<CovidDeclaration {...props} />);
+    const wrapper = component.find("[data-jest='haveCovidDeclarations'] input");
+    wrapper.first().simulate("change", { target: { value: true } });
+    setTimeout(() => {
+      component
+        .find("[data-jest='haveChangesToPlacement'] input")
+        .first()
+        .simulate("change", { target: { value: true } });
+      expect(
+        component.find("textarea[data-jest=howPlacementAdjusted]").length
+      ).toBe(1);
+      component
+        .find("textarea[data-jest=howPlacementAdjusted]")
+        .simulate("change", { target: { value: "Lorem ipsum" } });
+      component
+        .find("[data-jest='haveChangesToPlacement'] input")
+        .last()
+        .simulate("change", { target: { value: true } });
+      component
+        .find("[data-jest='haveChangesToPlacement'] input")
+        .first()
+        .simulate("change", { target: { value: true } });
+      expect(
+        component.find("textarea[data-jest=howPlacementAdjusted]").props().value
+      ).toBe("");
+    });
+  });
+
+  it("should render text box for typing supervisor name", () => {
+    const component = mount(<CovidDeclaration {...props} />);
+    const wrapper = component.find("[data-jest='haveCovidDeclarations'] input");
+    wrapper.first().simulate("change", { target: { value: true } });
+    setTimeout(() => {
+      expect(
+        component.find("[data-jest='educationSupervisorName']").length
+      ).toBe(1);
+    });
+  });
+
+  it("should render text box for typing supervisor email", () => {
+    const component = mount(<CovidDeclaration {...props} />);
+    const wrapper = component.find("[data-jest='haveCovidDeclarations'] input");
+    wrapper.first().simulate("change", { target: { value: true } });
+    setTimeout(() => {
+      expect(
+        component.find("[data-jest='educationSupervisorEmail']").length
+      ).toBe(1);
+    });
+  });
+
   it("should render previous section link buttons with correct label", () => {
     const wrapper = mount(<CovidDeclaration {...props} />);
 

--- a/src/components/forms/formr-part-b/__test__/FormRPartBPagination.test.tsx
+++ b/src/components/forms/formr-part-b/__test__/FormRPartBPagination.test.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { shallow, mount } from "enzyme";
+import FormRPartBPagination from "../Sections/FormRPartBPagination";
+import { submittedFormRPartBs } from "../../../../mock-data/submitted-formr-partb";
+
+const prevSection = jest.fn();
+const nextSection = jest.fn();
+const saveDraft = jest.fn();
+
+const props = {
+  values: submittedFormRPartBs[0],
+  previousSection: prevSection,
+  handleSubmit: nextSection,
+  saveDraft: saveDraft,
+  history: [],
+  section: 1,
+  prevSectionLabel: "Previous section navigation label",
+  nextSectionLabel: "Next section navigation label"
+};
+
+describe("Pagination component", () => {
+  it("renders without crashing", () => {
+    shallow(<FormRPartBPagination {...props} />);
+  });
+
+  it("mounts without crashing", () => {
+    mount(<FormRPartBPagination {...props} />);
+  });
+
+  it("renders previous and next section link when both section labels are present", () => {
+    const component = mount(<FormRPartBPagination {...props} />);
+    expect(component.find(".nhsuk-pagination__link--prev").length).toBe(1);
+    expect(component.find("a[data-jest='LinkToPreviousSection0']").length).toBe(
+      1
+    );
+
+    expect(component.find(".nhsuk-pagination__link--next").length).toBe(1);
+    expect(component.find("a[data-jest='LinkToNextSection2']").length).toBe(1);
+  });
+
+  it("renders next section link only when previous section label is empty", () => {
+    props.prevSectionLabel = "";
+    const component = mount(<FormRPartBPagination {...props} />);
+    expect(component.find(".nhsuk-pagination__link--prev").length).toBe(0);
+  });
+
+  it("should invoke prevSection when previous section link clicked", () => {
+    props.prevSectionLabel = "Previous section label";
+    const component = mount(<FormRPartBPagination {...props} />);
+    const wrapper = component.find(".nhsuk-pagination__link--prev");
+    wrapper.simulate("click");
+    expect(prevSection).toHaveBeenCalled();
+  });
+
+  it("should invoke nextSection when next section link clicked", () => {
+    const component = mount(<FormRPartBPagination {...props} />);
+    const wrapper = component.find(".nhsuk-pagination__link--next");
+    wrapper.simulate("click");
+    expect(nextSection).toHaveBeenCalled();
+  });
+});

--- a/src/models/FormRPartB.ts
+++ b/src/models/FormRPartB.ts
@@ -58,7 +58,7 @@ export interface CovidDeclaration {
   otherInformationForPanel: string;
   discussWithSupervisorChecked: boolean | string;
   discussWithSomeoneChecked: boolean | string;
-  haveChangesToPlacement: boolean | null;
+  haveChangesToPlacement: boolean | "";
   changeCircumstances: string;
   changeCircumstanceOther: string;
   howPlacementAdjusted: string;

--- a/src/models/FormRPartB.ts
+++ b/src/models/FormRPartB.ts
@@ -58,6 +58,12 @@ export interface CovidDeclaration {
   otherInformationForPanel: string;
   discussWithSupervisorChecked: boolean | string;
   discussWithSomeoneChecked: boolean | string;
+  haveChangesToPlacement: boolean | null;
+  changeCircumstances: string;
+  changeCircumstanceOther: string;
+  howPlacementAdjusted: string;
+  educationSupervisorName: string;
+  educationSupervisorEmail: string;
 }
 
 export interface FormSwitch {

--- a/src/models/FormRPartB.ts
+++ b/src/models/FormRPartB.ts
@@ -58,7 +58,7 @@ export interface CovidDeclaration {
   otherInformationForPanel: string;
   discussWithSupervisorChecked: boolean | string;
   discussWithSomeoneChecked: boolean | string;
-  haveChangesToPlacement: boolean | "";
+  haveChangesToPlacement: boolean | string;
   changeCircumstances: string;
   changeCircumstanceOther: string;
   howPlacementAdjusted: string;

--- a/src/services/TraineeReferenceService.ts
+++ b/src/services/TraineeReferenceService.ts
@@ -37,4 +37,8 @@ export class TraineeReferenceService extends ApiService {
   getDeclarationType(): Promise<AxiosResponse<any>> {
     return this.get("/declaration-type");
   }
+
+  getCovidChangeCircs(): Promise<AxiosResponse<any>> {
+    return this.get("/covid-change-circs");
+  }
 }


### PR DESCRIPTION
- Add COVID declaration form sections 3 & 4
- Fix form validation bug where validation lags behind change event (e.g. validation msg remained after field checked)
- Fix bug in COVID section and other sections so change event which hides a field also resets its value and therefore stops data persisting and being saved to db)





TICKET: TISNEW-4946