### PR TITLE
fix: Call the API with identity token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.11.0",

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -13,7 +13,7 @@ export class ApiService {
 
     this.axiosInstance.interceptors.request.use(async function (config) {
       let user = await Auth.currentAuthenticatedUser();
-      config.headers.authorization = `Bearer ${user.signInUserSession.accessToken.jwtToken}`;
+      config.headers.authorization = `Bearer ${user.signInUserSession.idToken.jwtToken}`;
 
       return config;
     });


### PR DESCRIPTION
API Gateway only supports authentication using identity tokens out of
the box, use `idToken` instead of `accessToken` so the API can be called
when secured.

At a later date the token should be switched back to the access token
once configuration can be done to use it.

TISNEW-4307