### PR TITLE
Add/fetch params

### DIFF
--- a/generate-build-version.ts
+++ b/generate-build-version.ts
@@ -12,7 +12,7 @@ var jsonContent = JSON.stringify(jsonData);
 
 fs.writeFile("./public/meta.json", jsonContent, "utf8", (err: any) =>
   err
-    ? console.log(err)
+    ? console.log(`Something went wrong writing meta.json file: ${err}`)
     : console.log(
         `meta.json file with latest version (${appVersion}) successfully written`
       )

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.11.0",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -7,7 +7,6 @@ import thunk from "redux-thunk";
 import configureMockStore from "redux-mock-store";
 import Login from "./components/authentication/Login";
 import { BrowserRouter } from "react-router-dom";
-import { signInButton } from "aws-amplify";
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);

--- a/src/utilities/CacheUtilities.ts
+++ b/src/utilities/CacheUtilities.ts
@@ -19,42 +19,35 @@ export class CacheUtilities {
     return false;
   }
 
-  public static async UnregisterServiceWorker(): Promise<null | undefined> {
-    try {
-      if ("serviceWorker" in navigator) {
-        const registrations = await navigator.serviceWorker.getRegistrations();
-        registrations.forEach(registration => registration.unregister());
-      }
-    } catch (error) {
-      return null;
-    }
+  public static async UnregisterServiceWorker(): Promise<void> {
+    if (navigator.serviceWorker.controller != null) {
+      const registrations: readonly ServiceWorkerRegistration[] = await navigator.serviceWorker.getRegistrations();
+      registrations.forEach(registration => registration.unregister());
+      console.log("SW unregistered");
+    } else console.log("no SW to unregister");
   }
 
-  public static async ClearCaches(): Promise<null | undefined> {
-    try {
-      if ("caches" in window) {
-        const keys: string[] = await caches.keys();
-        keys.forEach(async name => await caches.delete(name));
-      }
-    } catch (error) {
-      return null;
-    }
+  public static async ClearCaches(): Promise<void> {
+    if ("caches" in window) {
+      const keys: string[] = await caches.keys();
+      keys.forEach(async name => await caches.delete(name));
+    } else console.log("no caches to clear");
   }
-
-  public static async ReloadPage(): Promise<null | undefined> {
-    try {
-      window.location.reload();
-    } catch (error) {
-      return null;
-    }
+  public static async ReloadPage(): Promise<void> {
+    window.location.reload();
+    console.log("page reloaded");
   }
 
   public static async FetchMetaFile(): Promise<string | null> {
     try {
-      const response = await fetch("/meta.json");
+      const response = await fetch(`/meta.json?${new Date().getTime()}`, {
+        cache: "no-cache"
+      });
       const meta = await response.json();
+      console.log(`fetch success: ${meta.version}`);
       return meta.version;
     } catch (error) {
+      console.error(`fetch error: ${error}`);
       return null;
     }
   }

--- a/src/utilities/CacheUtilities.ts
+++ b/src/utilities/CacheUtilities.ts
@@ -31,6 +31,7 @@ export class CacheUtilities {
     if ("caches" in window) {
       const keys: string[] = await caches.keys();
       keys.forEach(async name => await caches.delete(name));
+      console.log("caches cleared");
     } else console.log("no caches to clear");
   }
   public static async ReloadPage(): Promise<void> {

--- a/src/utilities/__test__/CacheUtilities.test.ts
+++ b/src/utilities/__test__/CacheUtilities.test.ts
@@ -61,6 +61,10 @@ describe("CacheUtilities", () => {
   describe("FetchMetaFile", () => {
     const globalAny: any = global;
 
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
     it("should fetch a meta.json file", async () => {
       globalAny.fetch = jest.fn(() =>
         Promise.resolve({
@@ -83,7 +87,7 @@ describe("CacheUtilities", () => {
 
       const result = await CacheUtilities.FetchMetaFile();
       expect(result).toEqual(null);
-      expect(fetch).toHaveBeenCalledWith("/meta.json");
+      expect(fetch).toBeCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
- Add fetch params to ensure meta.json file is not cached
- Add more logs to track the cache-busting process on the client more easily 

Note: This PR is just to provide further cache-busting testing. These changes can be reverted if they are not needed / don't work.

