### PR TITLE
Redesign Covid Form - Section1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.11.0",

--- a/src/components/forms/formr-part-b/Sections/CovidDeclaration.tsx
+++ b/src/components/forms/formr-part-b/Sections/CovidDeclaration.tsx
@@ -147,7 +147,7 @@ const CovidDeclaration: FunctionComponent<SectionProps> = (
                       <p>
                         By signing this document, you are confirming that ALL
                         details are correct and that you have made an honest
-                        declaration on accordance with the professional
+                        declaration in accordance with the professional
                         standards set out by the General Medica Council in Good
                         Medical Practice.
                       </p>
@@ -174,14 +174,23 @@ const CovidDeclaration: FunctionComponent<SectionProps> = (
                           value: d
                         };
                       })}
-                      conditional={
-                        <TextInputField
-                          label=""
-                          name="covidDeclarationDto.reasonOfSelfRate"
-                          rows={5}
-                        />
-                      }
+                      onChange={() => {
+                        setFieldValue(
+                          "covidDeclarationDto.reasonOfSelfRate",
+                          null,
+                          false
+                        );
+                      }}
                     />
+                    {values.covidDeclarationDto?.selfRateForCovid !==
+                    COVID_RESULT_DECLARATIONS[2] ? (
+                      <TextInputField
+                        label="Please explain your reason for your progress self-rating."
+                        name="covidDeclarationDto.reasonOfSelfRate"
+                        rows={5}
+                      />
+                    ) : null}
+
                     <Label>
                       <b>
                         2. Please add other information you wish to provide for

--- a/src/components/forms/formr-part-b/ValidationSchema.ts
+++ b/src/components/forms/formr-part-b/ValidationSchema.ts
@@ -167,10 +167,18 @@ export const CovidSectionValidationSchema = yup.object({
           "Covid Training Progress",
           300
         ),
-        reasonOfSelfRate: StringValidationSchema(
-          "Progress self-rate reason",
-          1000
-        ),
+        reasonOfSelfRate: yup
+          .string()
+          .nullable()
+          .when("selfRateForCovid", {
+            is: selfRate =>
+              selfRate !==
+              "Satisfactory progress for stage of training and required competencies met",
+            then: yup
+              .string()
+              .nullable()
+              .required("Reason for self-rate is required")
+          }),
         otherInformationForPanel: yup
           .string()
           .nullable()

--- a/src/components/forms/formr-part-b/ValidationSchema.ts
+++ b/src/components/forms/formr-part-b/ValidationSchema.ts
@@ -168,7 +168,7 @@ export const CovidSectionValidationSchema = yup.object({
           300
         ),
         reasonOfSelfRate: StringValidationSchema(
-          "Covid Training Progress Reason",
+          "Progress self-rate reason",
           1000
         ),
         otherInformationForPanel: StringValidationSchema(

--- a/src/components/forms/formr-part-b/ValidationSchema.ts
+++ b/src/components/forms/formr-part-b/ValidationSchema.ts
@@ -171,10 +171,10 @@ export const CovidSectionValidationSchema = yup.object({
           "Progress self-rate reason",
           1000
         ),
-        otherInformationForPanel: StringValidationSchema(
-          "Other Information for Panel",
-          2000
-        ),
+        otherInformationForPanel: yup
+          .string()
+          .nullable()
+          .max(1000, "You have reached the maximum length allowed"),
         educationSupervisorName: StringValidationSchema(
           "Education Supervisor Name",
           300

--- a/src/components/forms/formr-part-b/View.tsx
+++ b/src/components/forms/formr-part-b/View.tsx
@@ -579,14 +579,16 @@ class View extends React.PureComponent<ViewProps> {
                         {formData.covidDeclarationDto?.selfRateForCovid}
                       </SummaryList.Value>
                     </SummaryList.Row>
-                    <SummaryList.Row>
-                      <SummaryList.Key>
-                        Covid Training Progress Reason
-                      </SummaryList.Key>
-                      <SummaryList.Value>
-                        {formData.covidDeclarationDto?.reasonOfSelfRate}
-                      </SummaryList.Value>
-                    </SummaryList.Row>
+                    {formData.covidDeclarationDto?.reasonOfSelfRate ? (
+                      <SummaryList.Row>
+                        <SummaryList.Key>
+                          Covid Training Progress Reason
+                        </SummaryList.Key>
+                        <SummaryList.Value>
+                          {formData.covidDeclarationDto?.reasonOfSelfRate}
+                        </SummaryList.Value>
+                      </SummaryList.Row>
+                    ) : null}
                     <SummaryList.Row>
                       <SummaryList.Key>
                         Other Information for ARCP Panel


### PR DESCRIPTION
- Make additional mandatory text field only appear when options 1 or 2 selected
- Make text field at the end of the section 1 non-mandatory - with a word limit of 1000 characters
- Minor version bump


TISNEW-5243