### PR TITLE
Fix/immigration other

### DIFF
--- a/cypress/integration/formr-a/formr-a.spec.ts
+++ b/cypress/integration/formr-a/formr-a.spec.ts
@@ -61,8 +61,13 @@ describe("Form R (Part A)", () => {
           //Test for 'Other' immigration status
           cy.get("#immigrationStatus")
             .should("be.visible")
-            .select("Other")
-            .should("have.value", "Other");
+            .select(
+              "Other immigration categories i.e. overseas government employees, innovators etc."
+            )
+            .should(
+              "have.value",
+              "Other immigration categories i.e. overseas government employees, innovators etc."
+            );
           cy.get("#otherImmigrationStatus")
             .should("be.visible")
             .type("My special status")
@@ -206,8 +211,13 @@ describe("Form R (Part A)", () => {
           //Test for 'Other' immigration status
           cy.get("#immigrationStatus")
             .should("be.visible")
-            .select("Other")
-            .should("have.value", "Other");
+            .select(
+              "Other immigration categories i.e. overseas government employees, innovators etc."
+            )
+            .should(
+              "have.value",
+              "Other immigration categories i.e. overseas government employees, innovators etc."
+            );
           cy.get("#otherImmigrationStatus")
             .should("be.visible")
             .clear()

--- a/cypress/integration/formr-b/formr-b.spec.ts
+++ b/cypress/integration/formr-b/formr-b.spec.ts
@@ -4,9 +4,7 @@
 let isCovid = false;
 
 before(() => {
-  cy.checkFlags("COVID").then(flag => {
-    isCovid = flag;
-  });
+  isCovid = true;
 });
 
 let currentDate = Cypress.moment().format("YYYY-MM-DD");

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -52,8 +52,13 @@ Cypress.Commands.add(
     //Test for 'Other' immigration status
     cy.get("#immigrationStatus")
       .should("be.visible")
-      .select("Other")
-      .should("have.value", "Other");
+      .select(
+        "Other immigration categories i.e. overseas government employees, innovators etc."
+      )
+      .should(
+        "have.value",
+        "Other immigration categories i.e. overseas government employees, innovators etc."
+      );
     cy.get("#otherImmigrationStatus")
       .should("be.visible")
       .should("have.value", "My special status");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.11.0",

--- a/src/components/forms/formr-part-a/Create.tsx
+++ b/src/components/forms/formr-part-a/Create.tsx
@@ -20,8 +20,10 @@ import { ValidationSchema } from "./ValidationSchema";
 import { GenericOwnProps } from "../../../redux/types";
 import {
   FORMR_PARTA_DECLARATIONS,
-  CCT_DECLARATION
+  CCT_DECLARATION,
+  IMMIGRATION_STATUS_OTHER_TISIDS
 } from "../../../utilities/Constants";
+import { ReferenceDataUtilities } from "../../../utilities/ReferenceDataUtilities";
 import Loading from "../../common/Loading";
 import { loadReferenceData } from "../../../redux/actions/reference-data-actions";
 import { TraineeReferenceService } from "../../../services/TraineeReferenceService";
@@ -173,11 +175,14 @@ class Create extends React.PureComponent<CreateProps> {
                   name="immigrationStatus"
                   options={immigrationStatus}
                 />
-                {values.immigrationStatus === "Other" ? (
+                {ReferenceDataUtilities.isMatchInReferenceData(
+                  IMMIGRATION_STATUS_OTHER_TISIDS,
+                  values.immigrationStatus,
+                  immigrationStatus
+                ) ? (
                   <TextInputField
                     name="otherImmigrationStatus"
-                    label="Other"
-                    placeholder="Please add your 'Other' immigration status"
+                    label="Please add your 'Other' immigration status"
                   />
                 ) : null}
                 <TextInputField

--- a/src/components/forms/formr-part-a/ValidationSchema.ts
+++ b/src/components/forms/formr-part-a/ValidationSchema.ts
@@ -26,7 +26,7 @@ export const ValidationSchema = yup.object({
       value => DateUtilities.IsMoreThanMinDate(value)
     ),
   gender: StringValidationSchema("Gender"),
-  immigrationStatus: StringValidationSchema("Immigration Status"),
+  immigrationStatus: StringValidationSchema("Immigration Status", 200),
   qualification: StringValidationSchema("Qualification"),
   dateAttained: dateValidationSchema("Date awarded (most recent qualification)")
     .test(
@@ -59,7 +59,7 @@ export const ValidationSchema = yup.object({
     .string()
     .email("Email is invalid")
     .max(255, "Email must be shorter than 255 characters")
-    .required("Email"),
+    .required("Email address is required"),
   declarationType: yup
     .string()
     .required("You need to choose at least one Declaration")

--- a/src/components/forms/formr-part-a/View.tsx
+++ b/src/components/forms/formr-part-a/View.tsx
@@ -63,12 +63,18 @@ class View extends React.PureComponent<ViewProps> {
                 <SummaryList.Key>Immigration Status</SummaryList.Key>
                 <SummaryList.Value>
                   {formData.immigrationStatus}
-
-                  {formData.immigrationStatus === "Other" ? (
-                    <span>, {formData.otherImmigrationStatus}</span>
-                  ) : null}
                 </SummaryList.Value>
               </SummaryList.Row>
+
+              {formData.immigrationStatus.toLowerCase().includes("other") ? (
+                <SummaryList.Row>
+                  <SummaryList.Key>Other Immigration Status</SummaryList.Key>
+                  <SummaryList.Value>
+                    {formData.otherImmigrationStatus}
+                  </SummaryList.Value>
+                </SummaryList.Row>
+              ) : null}
+
               <SummaryList.Row>
                 <SummaryList.Key>
                   Primary Qualification (most recent)

--- a/src/models/KeyValue.ts
+++ b/src/models/KeyValue.ts
@@ -1,4 +1,5 @@
 export interface KeyValue {
   label: string;
   value: string;
+  tisId?: string;
 }

--- a/src/redux/actions/reference-data-actions.ts
+++ b/src/redux/actions/reference-data-actions.ts
@@ -123,6 +123,7 @@ export const loadReferenceData = (
 function getKeyValuesFromResponse(response: AxiosResponse<any[]>): KeyValue[] {
   return response.data.map<KeyValue>(d => {
     return {
+      tisId: d.tisId,
       label: d.label,
       value: d.label
     };

--- a/src/utilities/Constants.ts
+++ b/src/utilities/Constants.ts
@@ -34,3 +34,5 @@ export const NEED_DISCUSSION_WITH_SUPERVISOR =
 
 export const NEED_DISCUSSION_WITH_SOMEONE =
   "I have concerns with my training and / or wellbeing at the moment and would like to discuss with someone";
+
+export const IMMIGRATION_STATUS_OTHER_TISIDS = ["12", "13"];

--- a/src/utilities/ReferenceDataUtilities.ts
+++ b/src/utilities/ReferenceDataUtilities.ts
@@ -5,27 +5,14 @@ export class ReferenceDataUtilities {
       (item: KeyValue) => item.label === label
     );
 
-    if (typeof myObj !== "undefined") {
-      return myObj.tisId;
-    }
-    return null;
+    return myObj?.tisId;
   }
 
   public static isMatchInReferenceData(
-    tisId: string | string[],
+    tisId: string[],
     label: string,
     refData: KeyValue[]
   ) {
-    if (Array.isArray(tisId)) {
-      return tisId.some(id => {
-        return this.getIdFromLabel(refData, label) === id;
-      });
-    } else {
-      if (this.getIdFromLabel(refData, label) === tisId) {
-        return true;
-      }
-    }
-
-    return false;
+    return [...tisId].some(id => this.getIdFromLabel(refData, label) === id);
   }
 }

--- a/src/utilities/ReferenceDataUtilities.ts
+++ b/src/utilities/ReferenceDataUtilities.ts
@@ -1,0 +1,31 @@
+import { KeyValue } from "../models/KeyValue";
+export class ReferenceDataUtilities {
+  private static getIdFromLabel(refData: KeyValue[], label: string) {
+    const myObj: KeyValue | undefined = refData.find(
+      (item: KeyValue) => item.label === label
+    );
+
+    if (typeof myObj !== "undefined") {
+      return myObj.tisId;
+    }
+    return null;
+  }
+
+  public static isMatchInReferenceData(
+    tisId: string | string[],
+    label: string,
+    refData: KeyValue[]
+  ) {
+    if (Array.isArray(tisId)) {
+      return tisId.some(id => {
+        return this.getIdFromLabel(refData, label) === id;
+      });
+    } else {
+      if (this.getIdFromLabel(refData, label) === tisId) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/src/utilities/__test__/ReferenceDataUtilities.test.ts
+++ b/src/utilities/__test__/ReferenceDataUtilities.test.ts
@@ -1,0 +1,41 @@
+import { ReferenceDataUtilities } from "../ReferenceDataUtilities";
+import { KeyValue } from "../../models/KeyValue";
+
+const refData: KeyValue[] = [
+  { tisId: "1", label: "Label one", value: "Value one" },
+  { tisId: "2", label: "Label two", value: "Value two" },
+  { tisId: "3", label: "Label three", value: "Value three" }
+];
+
+describe("ReferenceDataUtilities", () => {
+  it("Should return true when matching tisID of '1' to label 'Label one'", () => {
+    expect(
+      ReferenceDataUtilities.isMatchInReferenceData("1", "Label one", refData)
+    ).toBe(true);
+  });
+
+  it("Should return true when matching tisID of '1 or 2' passed as an array to label 'Label one'", () => {
+    expect(
+      ReferenceDataUtilities.isMatchInReferenceData(
+        ["1", "2"],
+        "Label one",
+        refData
+      )
+    ).toBe(true);
+  });
+  it("Should return false when matching tisID of '1' to label 'Label two'", () => {
+    expect(
+      ReferenceDataUtilities.isMatchInReferenceData("1", "Label two", refData)
+    ).toBe(false);
+  });
+
+  it("Should return false when matching tisID of '1 or 2' passed as an array to label 'Label three'", () => {
+    expect(
+      ReferenceDataUtilities.isMatchInReferenceData(
+        ["1", "2"],
+        "Label three",
+        refData
+      )
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
+ Add utility function to search the reference data for label and retrieve the corresponding tisId and then compare that against any given value.  
+ Add new constants corresponding to the tisIds of the 2 immigration status items that represent a status of other
+ Refactor 'Other' free text box to conditionally show when either of the 'other' immigration status drop down items are selected
+ Set isCovid flag in E2E tests to true to fix current failing of tests on pre-prod