### PR TITLE
refactor: Migrate api service to new API endpoints

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -477,7 +477,7 @@ Cypress.Commands.add("checkFlags", name => {
   return cy
     .request({
       method: "GET",
-      url: `/forms/api/form-switches`
+      url: `/api/forms/form-switches`
     })
     .then(response => {
       expect(response.status).to.eq(200);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.1.0",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6299,6 +6299,11 @@
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
       }
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "argparse": {
       "version": "1.0.10",
@@ -13740,6 +13745,11 @@
         }
       }
     },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+    },
     "makeerror": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
@@ -19858,6 +19868,25 @@
         "glob": "^7.1.2"
       }
     },
+    "ts-node": {
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
+      "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
+      "requires": {
+        "arg": "^4.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+        }
+      }
+    },
     "ts-pnp": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.1.6.tgz",
@@ -21308,6 +21337,11 @@
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     },
     "yup": {
       "version": "0.29.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.11.0",

--- a/src/services/FormsService.ts
+++ b/src/services/FormsService.ts
@@ -5,7 +5,7 @@ import { FormRPartB, FormSwitch } from "../models/FormRPartB";
 
 export class FormsService extends ApiService {
   constructor() {
-    super("/forms/api");
+    super("/api/forms");
   }
 
   async saveTraineeFormRPartA(
@@ -21,7 +21,7 @@ export class FormsService extends ApiService {
   }
 
   async getTraineeFormRPartAList(): Promise<AxiosResponse<FormRPartA[]>> {
-    return this.get<FormRPartA[]>(`/formr-partas/${this.traineeTisId}`);
+    return this.get<FormRPartA[]>("/formr-partas");
   }
 
   async getTraineeFormRPartAByFormId(
@@ -36,7 +36,7 @@ export class FormsService extends ApiService {
   }
 
   async getTraineeFormRPartBList(): Promise<AxiosResponse<FormRPartB[]>> {
-    return this.get<FormRPartB[]>(`/formr-partbs/${this.traineeTisId}`);
+    return this.get<FormRPartB[]>("/formr-partbs");
   }
 
   async getTraineeFormRPartBByFormId(

--- a/src/services/TraineeProfileService.ts
+++ b/src/services/TraineeProfileService.ts
@@ -4,12 +4,10 @@ import { TraineeProfile } from "../models/TraineeProfile";
 
 export class TraineeProfileService extends ApiService {
   constructor() {
-    super("/trainee/api");
+    super("/api/trainee");
   }
 
   async getTraineeProfile(): Promise<AxiosResponse<TraineeProfile>> {
-    return this.get<TraineeProfile>(
-      `/trainee-profile/trainee/${this.traineeTisId}`
-    );
+    return this.get<TraineeProfile>("/profile");
   }
 }

--- a/src/services/TraineeReferenceService.ts
+++ b/src/services/TraineeReferenceService.ts
@@ -3,7 +3,7 @@ import { AxiosResponse } from "axios";
 
 export class TraineeReferenceService extends ApiService {
   constructor() {
-    super("/reference/api");
+    super("/api/reference");
   }
 
   getGenders(): Promise<AxiosResponse<any>> {

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -3,7 +3,6 @@ import { Auth } from "aws-amplify";
 
 export class ApiService {
   axiosInstance: AxiosInstance;
-  traineeTisId = 47165;
 
   constructor(baseUrl: string) {
     this.axiosInstance = axios.create({


### PR DESCRIPTION
A new set of API endpoints has been created with a shared `/api` parent
instead of individual `/api` children. Migrate to use the new endpoints,
which also no longer need the trainee's TIS ID to be provided.

TISNEW-3833