### PR TITLE
fix: Type in trainee profile error message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.11.0",

--- a/src/components/profile/personal-details/PersonalDetailsComponent.tsx
+++ b/src/components/profile/personal-details/PersonalDetailsComponent.tsx
@@ -10,7 +10,7 @@ interface IProps {
 
 const PersonalDetailsComponent: React.FC<IProps> = ({ personalDetails }) => {
   if (!personalDetails) {
-    return <div>Failed to laod data.</div>;
+    return <div>Failed to load data.</div>;
   }
 
   const fullName = `${personalDetails.title}. ${personalDetails.forenames} ${personalDetails.surname}`;


### PR DESCRIPTION
The error message displayed when no trainee data is available in the
trainee profile is incorrectly spelt.

NO-TICKET