### PR TITLE
Update actions/setup-node to v1.4.4

### DIFF
--- a/.github/workflows/analyze-with-sonarqube.yml
+++ b/.github/workflows/analyze-with-sonarqube.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Node.js for use with actions
-        uses: actions/setup-node@v1.1.0
+        uses: actions/setup-node@v1.4.4
         with:
           version: 14.15.0
       - run: npm install


### PR DESCRIPTION
**Problem**
- Build warning that the 'add-path' command is deprecated and will be disabled on 16/11/2020 
- Build SonarCloud scan: _WARN You are using Node.js version 8, which reached end-of-life. Support for this version will be dropped in future release, please upgrade Node.js to more recent version._

**Solution**
Update actions/setup-node to v1.4.4

TISNEW-5709