### PR TITLE
fix: node version syntax

### DIFF
--- a/.github/workflows/analyze-with-sonarqube.yml
+++ b/.github/workflows/analyze-with-sonarqube.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Node.js for use with actions
         uses: actions/setup-node@v1.4.4
         with:
-          version: 14.15.0
+          node-version: 14.15.0
       - run: npm install
       - run: npm run lint -- -f json -o eslint-report.json
       - run: npm test


### PR DESCRIPTION
Input 'version' property has been deprecated. Need to use 'node-version' property.

TISNEW-5709