### PR TITLE
Feat/Add new phone validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trainee-ui-app",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.11.0",

--- a/src/__snapshots__/App.snapshot.spec.tsx.snap
+++ b/src/__snapshots__/App.snapshot.spec.tsx.snap
@@ -165,7 +165,7 @@ Array [
                   }
                 }
               >
-                version: 0.8.0
+                version: 0.9.0
               </span>
             </a>
           </li>

--- a/src/components/forms/formr-part-a/Create.tsx
+++ b/src/components/forms/formr-part-a/Create.tsx
@@ -224,8 +224,13 @@ class Create extends React.PureComponent<CreateProps> {
                 <TextInputField
                   label="Contact Telephone"
                   name="telephoneNumber"
+                  hint="Spaces are allowed between the numbers (e.g. 0xxx xxx xxxx, +447xxx xxx xxx) but no dashes or brackets please."
                 />
-                <TextInputField label="Contact Mobile" name="mobileNumber" />
+                <TextInputField
+                  label="Contact Mobile"
+                  name="mobileNumber"
+                  hint="Spaces are allowed between the numbers (e.g. 07xxx xx xx xx, +447xxx xxx xxx) but no dashes or brackets please."
+                />
                 <TextInputField label="Email Address" name="email" />
               </Panel>
 

--- a/src/components/forms/formr-part-a/ValidationSchema.ts
+++ b/src/components/forms/formr-part-a/ValidationSchema.ts
@@ -1,12 +1,12 @@
 import * as yup from "yup";
 import { DateUtilities } from "../../../utilities/DateUtilities";
 import { StringValidationSchema } from "../StringValidationSchema";
-import { CCT_DECLARATION } from "../../../utilities/Constants";
-
-const phoneRegex = /^\s*\(?(020[7,8]{1}\)?[ ]?[1-9]{1}[0-9{2}[ ]?[0-9]{4})|(0[1-8]{1}[0-9]{3}\)?[ ]?[1-9]{1}[0-9]{2}[ ]?[0-9]{3})\s*$/g;
-const mobileRegex = /((\+44(\s\(0\)\s|\s0\s|\s)?)|0)7\d{3}(\s)?\d{6}/g;
-const postcodeRegex = /[A-Z]{1,2}[0-9]{1,2}[A-Z]?\s?[0-9][A-Z]{2}/i;
-const wholeTimeEquivalentRegex = /^((0\.[1-9]{1})?|(0\.([0-9]{1}[1-9]{1}|[1-9]{1}[0-9]{1}))|1(\.0{1,2})?)$/;
+import {
+  CCT_DECLARATION,
+  CHECK_PHONE_REGEX,
+  CHECK_POSTCODE_REGEX,
+  CHECK_WHOLE_TIME_EQUIVALENT_REGEX
+} from "../../../utilities/Constants";
 
 const dateValidationSchema = (fieldName: string) =>
   yup.date().required(`${fieldName} is required`);
@@ -46,16 +46,16 @@ export const ValidationSchema = yup.object({
   address2: StringValidationSchema("Address Line 2"),
 
   postCode: StringValidationSchema("Postcode", 8).matches(
-    postcodeRegex,
+    CHECK_POSTCODE_REGEX,
     "Please enter a valid postcode"
   ),
   telephoneNumber: StringValidationSchema("Contact Telephone").matches(
-    phoneRegex,
-    "Contact Telephone - requires a valid number"
+    CHECK_PHONE_REGEX,
+    "Contact Telephone - please provide a valid number with prefix (e.g. 0, +44, or 44), at least 10 digits (including area code), a maximum of 15 digits (to allow for your country code), with no dashes or brackets."
   ),
   mobileNumber: StringValidationSchema("Contact Mobile").matches(
-    mobileRegex,
-    "Contact Mobile - requires a valid number"
+    CHECK_PHONE_REGEX,
+    "Contact Mobile - please provide a valid number with prefix (e.g. 0, +44, or 44), at least 10 digits (including area code), a maximum of 15 digits (to allow for your country code), with no dashes or brackets."
   ),
   email: yup
     .string()
@@ -96,7 +96,7 @@ export const ValidationSchema = yup.object({
     .test(
       "wholeTimeEquivalent",
       "Programme Full Time Equivalent in Training needs to be a number less than or equal to 1 and greater than zero (a maximum of 2 decimal places)",
-      value => (value ? wholeTimeEquivalentRegex.test(value) : false)
+      value => (value ? CHECK_WHOLE_TIME_EQUIVALENT_REGEX.test(value) : false)
     )
     .nullable()
 });

--- a/src/components/forms/formr-part-a/__test__/ValidationSchema.test.tsx
+++ b/src/components/forms/formr-part-a/__test__/ValidationSchema.test.tsx
@@ -1,0 +1,51 @@
+import { CHECK_PHONE_REGEX } from "../../../../utilities/Constants";
+
+describe("Phone validation regex", () => {
+  it("should match a number less than 16 digits but more than 9 digits starting with 0", () => {
+    const telNum1 = "01511231234";
+    const telNum2 = "0088888888888888";
+    const telNum3 = "0169770000";
+    const telNum4 = "016977000";
+
+    expect(telNum1).toMatch(CHECK_PHONE_REGEX);
+    expect(telNum2).not.toMatch(CHECK_PHONE_REGEX);
+    expect(telNum3).toMatch(CHECK_PHONE_REGEX);
+    expect(telNum4).not.toMatch(CHECK_PHONE_REGEX);
+  });
+  it("should match a number less than 16 digits but more than 9 digits starting with a + and country code", () => {
+    const telNum1 = "+449999999999";
+    const telNum2 = "+2569999999999";
+    expect(telNum1).toMatch(CHECK_PHONE_REGEX);
+    expect(telNum2).toMatch(CHECK_PHONE_REGEX);
+  });
+  it("should match a number less than 16 digits but more than 9 digits starting with a country code and not a +", () => {
+    const telNum1 = "449999999999";
+    const telNum2 = "380999999999999";
+    expect(telNum1).toMatch(CHECK_PHONE_REGEX);
+    expect(telNum2).toMatch(CHECK_PHONE_REGEX);
+  });
+  it("should match number less than 16 digits but more than 9 digits with spaces between the numbers", () => {
+    const telNum1 = "0151 123 1234";
+    const telNum2 = "07777 77 77 77";
+    const telNum3 = "00 99 99 99 99 99 999";
+    const telNum4 = "+256 99 99 99 99 99";
+
+    expect(telNum1).toMatch(CHECK_PHONE_REGEX);
+    expect(telNum2).toMatch(CHECK_PHONE_REGEX);
+    expect(telNum3).toMatch(CHECK_PHONE_REGEX);
+    expect(telNum4).toMatch(CHECK_PHONE_REGEX);
+  });
+  it("should not match a number with a non-numeric character other than a +", () => {
+    const telNum1 = "0151 23 1234S";
+    const telNum2 = "*07777 77 77 77";
+    const telNum3 = "+256-9999999999";
+
+    expect(telNum1).not.toMatch(CHECK_PHONE_REGEX);
+    expect(telNum2).not.toMatch(CHECK_PHONE_REGEX);
+    expect(telNum3).not.toMatch(CHECK_PHONE_REGEX);
+  });
+  it("should not match a number with more than one +", () => {
+    const telNum1 = "++449999999999";
+    expect(telNum1).not.toMatch(CHECK_PHONE_REGEX);
+  });
+});

--- a/src/utilities/Constants.ts
+++ b/src/utilities/Constants.ts
@@ -36,3 +36,9 @@ export const NEED_DISCUSSION_WITH_SOMEONE =
   "I have concerns with my training and / or wellbeing at the moment and would like to discuss with someone";
 
 export const IMMIGRATION_STATUS_OTHER_TISIDS = ["12", "13"];
+
+export const CHECK_PHONE_REGEX = /^\+?(?:\d\s?){10,15}$/;
+
+export const CHECK_POSTCODE_REGEX = /[A-Z]{1,2}[0-9]{1,2}[A-Z]?\s?[0-9][A-Z]{2}/i;
+
+export const CHECK_WHOLE_TIME_EQUIVALENT_REGEX = /^((0\.[1-9]{1})?|(0\.([0-9]{1}[1-9]{1}|[1-9]{1}[0-9]{1}))|1(\.0{1,2})?)$/;


### PR DESCRIPTION
- Add phone validation to  to enable inputting of international numbers for those trainees without a UK contact number. It follows this international guidance https://en.wikipedia.org/wiki/E.164 (e.g. max 15 digits including country code)
- Add hint text to give more guidance 
- Improve error message to give further information on the allowed format

To do
- Next step could be utilising a phone validation library (e.g. https://www.npmjs.com/package/react-phone-input-2) which will be more robust and align with current UX best practices.
- Need to display some guidance to to steer the user to their ESR record to allow these updated numbers to be written to all of their TIS-related records. This isn’t included in any hint text for now until we get more user feedback/ decide what this looks like.

Note: Any failing e2e tests are being picked up on a separate ticket
